### PR TITLE
SHOWCASE-249-rest-api-credential-definitions-are-missing-on-the-open-api-spec

### DIFF
--- a/packages/bc-wallet-openapi/docs/diagram.md
+++ b/packages/bc-wallet-openapi/docs/diagram.md
@@ -47,9 +47,9 @@ classDiagram
         +description : String
         +order : int
         +type : StepType
-        +credentialDefinition : CredentialDefinition
         +createdAt : DateTime
         +updatedAt : DateTime
+        credentialDefinition : CredentialDefinition
         subFlow: Scenario
         actions: List~StepAction~
         asset: Asset

--- a/packages/bc-wallet-openapi/openapi/openapi.yaml
+++ b/packages/bc-wallet-openapi/openapi/openapi.yaml
@@ -2005,6 +2005,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/StepAction'
+        credentialDefinition:
+          $ref: '#/components/schemas/CredentialDefinition'
         asset:
           $ref: '#/components/schemas/Asset'
         createdAt:
@@ -2054,6 +2056,10 @@ components:
         asset:
           type: string
           description: Asset referenced by this step
+          example: 456e4567-e89b-12d3-a456-426614174000
+        credentialDefinition:
+          type: string
+          description: Credential definition ID
           example: 456e4567-e89b-12d3-a456-426614174000
     StepsResponse:
       properties:


### PR DESCRIPTION
Refactor: Move credentialDefinition property to the correct position in diagram.md and openapi.yaml for improved schema clarity