### PR TITLE
Adds support for runtime environment variables in Showcase-Creator application

### DIFF
--- a/apps/bc-wallet-showcase-creator/Dockerfile
+++ b/apps/bc-wallet-showcase-creator/Dockerfile
@@ -1,7 +1,7 @@
 #Build step
 FROM node:20-alpine AS builder
 WORKDIR /app
-RUN apk add --no-cache libc6-compat
+RUN apk add --no-cache libc6-compat bash
 RUN apk add --no-cache maven openjdk17
 RUN npm -g install pnpm
 
@@ -20,7 +20,7 @@ RUN pnpm run build --filter bc-wallet-showcase-creator
 #Runtime step
 FROM node:20-alpine AS runner
 WORKDIR /app
-RUN apk add --no-cache libc6-compat
+RUN apk add --no-cache libc6-compat bash
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 ENV NODE_ENV=production
@@ -31,8 +31,12 @@ ENV PORT=3050
 COPY --from=builder /app/apps/bc-wallet-showcase-creator/.next/standalone ./
 COPY --from=builder /app/apps/bc-wallet-showcase-creator/.next/static ./apps/bc-wallet-showcase-creator/.next/static
 COPY --from=builder /app/apps/bc-wallet-showcase-creator/public ./apps/bc-wallet-showcase-creator/public
+COPY --from=builder /app/apps/bc-wallet-showcase-creator/env.sh ./env.sh
+RUN chmod +x ./env.sh
 
 RUN chown -R nextjs:nodejs /app
 USER nextjs
 EXPOSE 3050
+
+ENTRYPOINT ["./env.sh"]
 CMD ["node", "apps/bc-wallet-showcase-creator/server.js"]

--- a/apps/bc-wallet-showcase-creator/app/[locale]/layout.tsx
+++ b/apps/bc-wallet-showcase-creator/app/[locale]/layout.tsx
@@ -1,5 +1,6 @@
 import type { PropsWithChildren } from 'react'
 import React from 'react'
+import Script from 'next/script'
 
 import { AppSidebar } from '@/components/app-sidebar'
 import { Footer } from '@/components/footer'
@@ -11,12 +12,14 @@ import { routing } from '@/i18n/routing'
 import { QueryProviders } from '@/providers/query-provider'
 import { ThemeProvider } from '@/providers/theme-provider'
 import { NextIntlClientProvider } from 'next-intl'
-import { Montserrat } from "next/font/google";
+import { Montserrat, Inter } from "next/font/google";
 import { getMessages, getTranslations } from 'next-intl/server'
 import { notFound } from 'next/navigation'
 import type { Locale, PageParams } from '@/types'
 
 import '../globals.css'
+
+const inter = Inter({ subsets: ['latin'] })
 
 const montserrat = Montserrat({
   variable: '--font-montserrat',
@@ -52,8 +55,19 @@ export default async function RootLayout({ children, params }: Params) {
   // Providing all messages to the client
   const messages = await getMessages()
 
+  // Get environment variables from server
+  const envVars = {
+    WALLET_URL: process.env.NEXT_PUBLIC_WALLET_URL,
+    SHOWCASE_BACKEND: process.env.NEXT_PUBLIC_SHOWCASE_BACKEND,
+  }
+
   return (
     <html lang={locale} suppressHydrationWarning>
+      <head>
+        <Script id="env-script" strategy="beforeInteractive">
+          {`window.__env = ${JSON.stringify(envVars)};`}
+        </Script>
+      </head>
       <body className={`${montserrat.variable} antialiased`}>
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
           <QueryProviders>

--- a/apps/bc-wallet-showcase-creator/env.sh
+++ b/apps/bc-wallet-showcase-creator/env.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+ENVSH_ENV="${ENVSH_ENV:-./.env}"
+ENVSH_PREFIX="${ENVSH_PREFIX:-NEXT_PUBLIC_}"
+ENVSH_PREFIX_STRIP="${ENVSH_PREFIX_STRIP:-true}"
+ENVSH_PREPEND="${ENVSH_PREPEND:-window.__env = {}"
+ENVSH_APPEND="${ENVSH_APPEND:-}"
+ENVSH_OUTPUT="${ENVSH_OUTPUT:-./apps/bc-wallet-showcase-creator/public/__env.js}"
+ENVSH_VERBOSE="${ENVSH_VERBOSE:-false}"
+
+mkdir -p "$(dirname "$ENVSH_OUTPUT")"
+
+echo "$ENVSH_PREPEND" > "$ENVSH_OUTPUT"
+
+if [ -f "$ENVSH_ENV" ]; then
+  if [ "$ENVSH_VERBOSE" = "true" ]; then
+    echo "Loading environment variables from $ENVSH_ENV"
+  fi
+  
+  while IFS= read -r line || [ -n "$line" ]; do
+    if [[ $line =~ ^# ]] || [[ -z $line ]]; then
+      continue
+    fi
+    
+    if [[ $line =~ ^([^=]+)=(.*)$ ]]; then
+      key="${BASH_REMATCH[1]}"
+      value="${BASH_REMATCH[2]}"
+      
+      if [[ $key == $ENVSH_PREFIX* ]]; then
+        if [ "$ENVSH_PREFIX_STRIP" = "true" ]; then
+          output_key="${key#$ENVSH_PREFIX}"
+        else
+          output_key="$key"
+        fi
+        
+        echo "  $output_key: \"$value\"," >> "$ENVSH_OUTPUT"
+        
+        if [ "$ENVSH_VERBOSE" = "true" ]; then
+          echo "Added $output_key from .env file"
+        fi
+      fi
+    fi
+  done < "$ENVSH_ENV"
+fi
+
+for var in $(env | sort); do
+  if [[ $var =~ ^([^=]+)=(.*)$ ]]; then
+    key="${BASH_REMATCH[1]}"
+    value="${BASH_REMATCH[2]}"
+    
+    if [[ $key == $ENVSH_PREFIX* ]]; then
+      if [ "$ENVSH_PREFIX_STRIP" = "true" ]; then
+        output_key="${key#$ENVSH_PREFIX}"
+      else
+        output_key="$key"
+      fi
+      
+      sed -i "/^  $output_key: /d" "$ENVSH_OUTPUT"
+      
+      echo "  $output_key: \"$value\"," >> "$ENVSH_OUTPUT"
+      
+      if [ "$ENVSH_VERBOSE" = "true" ]; then
+        echo "Added $output_key from environment"
+      fi
+    fi
+  fi
+done
+
+echo "}" >> "$ENVSH_OUTPUT"
+
+if [ "$ENVSH_VERBOSE" = "true" ]; then
+  echo "Environment variables written to $ENVSH_OUTPUT"
+fi
+
+echo "Generated __env.js at: $ENVSH_OUTPUT"
+ls -la $(dirname "$ENVSH_OUTPUT")
+cat "$ENVSH_OUTPUT"
+
+if [ $# -gt 0 ]; then
+  exec "$@"
+fi 

--- a/apps/bc-wallet-showcase-creator/env.ts
+++ b/apps/bc-wallet-showcase-creator/env.ts
@@ -1,19 +1,46 @@
 import { createEnv } from "@t3-oss/env-nextjs";
 import { z } from "zod";
- 
+
+const runtimeClientSchema = {
+  NEXT_PUBLIC_WALLET_URL: z.string().min(1),
+  NEXT_PUBLIC_SHOWCASE_BACKEND: z.string().min(1),
+};
+
+const runtimeClientProcess = {
+  NEXT_PUBLIC_WALLET_URL: 
+    typeof window !== "undefined" && window.__env?.WALLET_URL 
+      ? window.__env.WALLET_URL 
+      : process.env.NEXT_PUBLIC_WALLET_URL,
+  NEXT_PUBLIC_SHOWCASE_BACKEND: 
+    typeof window !== "undefined" && window.__env?.SHOWCASE_BACKEND 
+      ? window.__env.SHOWCASE_BACKEND 
+      : process.env.NEXT_PUBLIC_SHOWCASE_BACKEND,
+};
+
 export const env = createEnv({
   server: {
     AUTH_SECRET: z.string().min(1),
     AUTH_KEYCLOAK_ID: z.string().min(1),
     AUTH_KEYCLOAK_SECRET: z.string().min(1),
-    AUTH_KEYCLOAK_ISSUER: z.string().url(),
+    AUTH_KEYCLOAK_ISSUER: z.string().min(1),
   },
-  client: {
-    NEXT_PUBLIC_WALLET_URL: z.string().url(),
-    NEXT_PUBLIC_SHOWCASE_BACKEND: z.string().url(),
+  client: runtimeClientSchema,
+  runtimeEnv: {
+    AUTH_SECRET: process.env.AUTH_SECRET,
+    AUTH_KEYCLOAK_ID: process.env.AUTH_KEYCLOAK_ID,
+    AUTH_KEYCLOAK_SECRET: process.env.AUTH_KEYCLOAK_SECRET,
+    AUTH_KEYCLOAK_ISSUER: process.env.AUTH_KEYCLOAK_ISSUER,
+    NEXT_PUBLIC_WALLET_URL: runtimeClientProcess.NEXT_PUBLIC_WALLET_URL,
+    NEXT_PUBLIC_SHOWCASE_BACKEND: runtimeClientProcess.NEXT_PUBLIC_SHOWCASE_BACKEND,
   },
-  experimental__runtimeEnv: {
-    NEXT_PUBLIC_WALLET_URL: process.env.NEXT_PUBLIC_WALLET_URL,
-    NEXT_PUBLIC_SHOWCASE_BACKEND: process.env.NEXT_PUBLIC_SHOWCASE_BACKEND,
-  },
+  skipValidation: process.env.NODE_ENV === "production" || !!process.env.SKIP_ENV_VALIDATION,
 });
+
+declare global {
+  interface Window {
+    __env?: {
+      WALLET_URL?: string;
+      SHOWCASE_BACKEND?: string;
+    };
+  }
+}

--- a/apps/bc-wallet-showcase-creator/lib/apiService.ts
+++ b/apps/bc-wallet-showcase-creator/lib/apiService.ts
@@ -4,7 +4,7 @@ class ApiService {
   private baseUrl: string
 
   public constructor(baseUrl: string) {
-    this.baseUrl = baseUrl
+    this.baseUrl = baseUrl;
   }
 
   private async request<T>(method: string, url: string, data?: Record<string, unknown>): Promise<T | void> {
@@ -63,7 +63,6 @@ class ApiService {
     return this.request<T>('DELETE', url)
   }
 }
-
 
 const apiClient = new ApiService(env.NEXT_PUBLIC_SHOWCASE_BACKEND)
 

--- a/apps/bc-wallet-showcase-creator/lib/utils.ts
+++ b/apps/bc-wallet-showcase-creator/lib/utils.ts
@@ -21,6 +21,5 @@ export const convertBase64 = (file: File): Promise<string> => {
   })
 }
 
-
-export const baseUrl = env.NEXT_PUBLIC_SHOWCASE_BACKEND || 'https://bcshowcase-api.dev.nborbit.ca'
+export const baseUrl = env.NEXT_PUBLIC_SHOWCASE_BACKEND;
 

--- a/apps/bc-wallet-showcase-creator/next.config.ts
+++ b/apps/bc-wallet-showcase-creator/next.config.ts
@@ -18,6 +18,9 @@ const nextConfig: NextConfig = {
     dangerouslyAllowSVG: true,
   },
   transpilePackages: ["@t3-oss/env-nextjs", "@t3-oss/env-core"],
+  publicRuntimeConfig: {
+    staticFolder: '/public',
+  },
 };
 
 export default withNextIntl(nextConfig);

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
     "turbo": "latest",
-    "typescript": "^5.8.2"
+    "typescript": "^5.8.2",
+    "@t3-oss/env-nextjs": "^0.12.0"
   },
   "engines": {
     "node": ">= 20.0.0 < 22"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ importers:
 
   .:
     devDependencies:
+      '@t3-oss/env-nextjs':
+        specifier: ^0.12.0
+        version: 0.12.0(typescript@5.8.2)(zod@3.24.2)
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14


### PR DESCRIPTION
- Added env.sh script that generates a JavaScript file with environment variables at container startup
- Modified env.ts to check for runtime environment variables from window.__env before falling back to build-time variables- 
- Updated layout.tsx to inject environment variables directly into the HTML
- Configured Docker to use the env.sh script as the entrypoint
- Removed hardcoded environment variable values for better security
- Updated environment variable validation to be skipped in production