### PR TITLE
Feat: upgrade rabbitmq and psql helm charts 

### DIFF
--- a/charts/bc-wallet/Chart.yaml
+++ b/charts/bc-wallet/Chart.yaml
@@ -4,7 +4,7 @@ description: BC Wallet services with PostgreSQL and RabbitMQ
 version: 0.1.0
 dependencies:
   - name: postgresql
-    version: "12.5.7"
+    version: "16.6.3"
     repository: "https://charts.bitnami.com/bitnami"
     condition: postgresql.enabled
   - name: rabbitmq

--- a/charts/bc-wallet/templates/_helpers.tpl
+++ b/charts/bc-wallet/templates/_helpers.tpl
@@ -107,14 +107,46 @@ Create a default fully qualified rabbitmq name.
 {{- end -}}
 
 {{/*
-Get the rabbitmq password key.
+Get the password key to be retrieved from RabbitMQ secret.
 */}}
 {{- define "bc-wallet.rabbitmq.passwordKey" -}}
-{{- if .Values.rabbitmq.auth.secretKeys.passwordKey -}}
-{{- printf "%s" .Values.rabbitmq.auth.secretKeys.passwordKey -}}
+{{- if .Values.rabbitmq.auth.existingSecretKey -}}
+    {{- .Values.rabbitmq.auth.existingSecretKey -}}
 {{- else -}}
-rabbitmq-password
+    {{- print "rabbitmq-password" -}}
 {{- end -}}
+{{- end -}}
+
+{{/*
+Get the username key to be retrieved from RabbitMQ secret.
+*/}}
+{{- define "bc-wallet.rabbitmq.usernameKey" -}}
+{{- print "rabbitmq-username" -}}
+{{- end -}}
+
+{{/*
+Get the name of the RabbitMQ secret.
+*/}}
+{{- define "bc-wallet.rabbitmq.secretName" -}}
+{{- if .Values.rabbitmq.auth.existingSecret -}}
+    {{- .Values.rabbitmq.auth.existingSecret -}}
+{{- else -}}
+    {{- printf "%s-rabbitmq" (include "common.names.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the RabbitMQ host.
+*/}}
+{{- define "bc-wallet.rabbitmq.host" -}}
+{{- printf "%s-rabbitmq" .Release.Name -}}
+{{- end -}}
+
+{{/*
+Get the RabbitMQ port.
+*/}}
+{{- define "bc-wallet.rabbitmq.port" -}}
+{{- print "5672" -}}
 {{- end -}}
 
 {{/*

--- a/charts/bc-wallet/templates/traction-adapter/deployment.yaml
+++ b/charts/bc-wallet/templates/traction-adapter/deployment.yaml
@@ -56,11 +56,11 @@ spec:
                 name: {{ include "bc-wallet.rabbitmq.secretName" . }}
                 key: {{ include "bc-wallet.rabbitmq.passwordKey" . }}
           {{- range $key, $value := .Values.traction_adapter.env }}
-          {{- if and (ne $key "RABBITMQ_HOST") (kindIs "map" $value) }}
+          {{- if and (ne $key "RABBITMQ_HOST") (ne $key "RABBITMQ_PORT") (ne $key "RABBITMQ_USERNAME") (ne $key "RABBITMQ_PASSWORD") (kindIs "map" $value) }}
           - name: {{ $key }}
             valueFrom:
               {{- toYaml $value | nindent 14 }}
-          {{- else if ne $key "RABBITMQ_HOST" }}
+          {{- else if and (ne $key "RABBITMQ_HOST") (ne $key "RABBITMQ_PORT") (ne $key "RABBITMQ_USERNAME") (ne $key "RABBITMQ_PASSWORD") }}
           - name: {{ $key }}
             value: {{ $value | quote }}
           {{- end }}

--- a/charts/bc-wallet/templates/traction-adapter/deployment.yaml
+++ b/charts/bc-wallet/templates/traction-adapter/deployment.yaml
@@ -41,23 +41,30 @@ spec:
         - containerPort: {{ .Values.traction_adapter.port }}
           name: http
         env:
-        - name: RABBITMQ_HOST
-          value: {{ .Release.Name }}-rabbitmq
-        {{- range $key, $value := .Values.traction_adapter.env }}
-        {{- if and (ne $key "RABBITMQ_HOST") (kindIs "map" $value) }}
-        - name: {{ $key }}
-          valueFrom:
-            {{- toYaml $value | nindent 12 }}
-        {{- else if ne $key "RABBITMQ_HOST" }}
-        - name: {{ $key }}
-          value: {{ $value | quote }}
-        {{- end }}
-        {{- end }}
-        - name: RABBITMQ_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "bc-wallet.rabbitmq.secret.name" . }}
-              key: {{ include "bc-wallet.rabbitmq.passwordKey" . }}
+          - name: RABBITMQ_HOST
+            value: {{ include "bc-wallet.rabbitmq.host" . | quote }}
+          - name: RABBITMQ_PORT
+            value: {{ include "bc-wallet.rabbitmq.port" . | quote }}
+          - name: RABBITMQ_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "bc-wallet.rabbitmq.secretName" . }}
+                key: {{ include "bc-wallet.rabbitmq.usernameKey" . }}
+          - name: RABBITMQ_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "bc-wallet.rabbitmq.secretName" . }}
+                key: {{ include "bc-wallet.rabbitmq.passwordKey" . }}
+          {{- range $key, $value := .Values.traction_adapter.env }}
+          {{- if and (ne $key "RABBITMQ_HOST") (kindIs "map" $value) }}
+          - name: {{ $key }}
+            valueFrom:
+              {{- toYaml $value | nindent 14 }}
+          {{- else if ne $key "RABBITMQ_HOST" }}
+          - name: {{ $key }}
+            value: {{ $value | quote }}
+          {{- end }}
+          {{- end }}
         resources:
           {{- toYaml .Values.traction_adapter.resources | nindent 12 }}
       serviceAccountName: {{ if .Values.traction_adapter.serviceAccount.create }}{{ if .Values.traction_adapter.serviceAccount.name }}{{ .Values.traction_adapter.serviceAccount.name }}{{ else }}{{ $.Release.Name }}-{{ .Values.traction_adapter.name }}{{ end }}{{ end }}

--- a/charts/bc-wallet/values.yaml
+++ b/charts/bc-wallet/values.yaml
@@ -388,7 +388,7 @@ rabbitmq:
     username: "guest"
     password: ""
     existingSecret: ""
-    existingSecretPasswordKey: "rabbitmq-password"
+    existingSecretKey: "rabbitmq-password"
     erlangCookie: ""
     existingErlangSecret: ""
     existingErlangSecretKey: "rabbitmq-erlang-cookie"


### PR DESCRIPTION
Updated following Helm chart versions
1. Rabbitmq. Chart Version: 15.5.1. App Version: 4.0.8
2. Postgresql. Chart Version: 16.6.3. App Version: 17.4.0

And also updated the helm templates to support new chart secrets.