### PR TITLE
feat: Add validation for proof request attributes and predicates

### DIFF
--- a/apps/bc-wallet-demo-web/src/components/ActionCTA.tsx
+++ b/apps/bc-wallet-demo-web/src/components/ActionCTA.tsx
@@ -15,10 +15,21 @@ export const ActionCTA: React.FC<Props> = ({ isCompleted, onFail }) => {
   const renderCTA = !isCompleted ? (
     <motion.div variants={fade} key="openWallet">
       <p>
-        Accept the request in your <a href="bcwallet://">wallet {isMobile && 'or'}</a>
+        Accept the request in your{' '}
+        {isMobile ? (
+          <a href="bcwallet://" className="text-blue-600 underline">
+            wallet or
+          </a>
+        ) : (
+          <span className="text-gray-500">wallet</span>
+        )}
       </p>
+
       {isMobile && (
-        <a href="bcwallet://" className="underline underline-offset-2 mt-2">
+        <a
+          href="bcwallet://"
+          className="underline underline-offset-2 mt-2 inline-flex items-center gap-1 text-blue-600"
+        >
           open in wallet
           <FiExternalLink className="inline pb-1" />
         </a>

--- a/apps/bc-wallet-demo-web/src/pages/onboarding/steps/actions/AcceptCredentialAction.tsx
+++ b/apps/bc-wallet-demo-web/src/pages/onboarding/steps/actions/AcceptCredentialAction.tsx
@@ -105,6 +105,16 @@ export const AcceptCredentialAction: React.FC<Props> = (props: Props) => {
   }
 
   const sendNewCredentials = () => {
+    credentialDefinitions.forEach(credentialDefinition => {
+      if (isDeepLink) {
+        dispatch(issueDeepCredential({ connectionId, credentialDefinition }))
+      } else {
+        dispatch(issueCredential({ connectionId, credentialDefinition }))
+      }
+      track({
+        id: 'credential_issued',
+      })
+    })
     closeFailedRequestModal()
   }
 

--- a/apps/bc-wallet-demo-web/src/pages/useCase/Section.tsx
+++ b/apps/bc-wallet-demo-web/src/pages/useCase/Section.tsx
@@ -230,7 +230,7 @@ export const Section: FC<Props> = (props: Props) => {
                     },
                   })
                 }}
-                disabled={isBackDisabled}
+                disabled={isBackDisabled || currentScenario.steps.length === currentStep.order}
               />
               {currentScenario.steps.length === currentStep.order ? (
                 <Button text="COMPLETE" onClick={() => setCompleted(true)} />

--- a/apps/bc-wallet-demo-web/src/pages/useCase/steps/actions/PresentCredentialAction.tsx
+++ b/apps/bc-wallet-demo-web/src/pages/useCase/steps/actions/PresentCredentialAction.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react'
 
 import { trackSelfDescribingEvent } from '@snowplow/browser-tracker'
-import { motion } from 'framer-motion'
+import { AnimatePresence, motion } from 'framer-motion'
 
 import { ActionCTA } from '../../../../components/ActionCTA'
 import { useAppDispatch } from '../../../../hooks/hooks'
@@ -11,6 +11,8 @@ import { useSocket } from '../../../../slices/socket/socketSelector'
 import type { CredentialRequest } from '../../../../slices/types'
 import { FailedRequestModal } from '../../../onboarding/components/FailedRequestModal'
 import { ProofAttributesCard } from '../../components/ProofAttributesCard'
+import { dropIn, standardFade } from '../../../../FramerAnimations'
+import { SmallButton } from '../../../../components/SmallButton'
 
 export interface Props {
   proof?: any
@@ -38,6 +40,7 @@ export const PresentCredentialAction: React.FC<Props> = ({
     proof?.state === 'done'
 
   const [isFailedRequestModalOpen, setIsFailedRequestModalOpen] = useState(false)
+  const [isDeclineModalOpen, setIsDeclineModalOpen] = useState(false)
   const showFailedRequestModal = () => setIsFailedRequestModalOpen(true)
   const closeFailedRequestModal = () => setIsFailedRequestModalOpen(false)
   const proofRequestCreated = useRef(false);
@@ -129,6 +132,9 @@ export const PresentCredentialAction: React.FC<Props> = ({
     ) {
       dispatch(fetchProofById(message.presentation_exchange_id))
     }
+    if(message.state === 'abandoned') {
+      setIsDeclineModalOpen(true)
+    }
   }, [message])
 
   const sendNewRequest = () => {
@@ -138,6 +144,7 @@ export const PresentCredentialAction: React.FC<Props> = ({
     }
     proofRequestCreated.current = true
     closeFailedRequestModal()
+    setIsDeclineModalOpen(false)
   }
 
   console.log('Received Proof:', proof)
@@ -179,6 +186,54 @@ export const PresentCredentialAction: React.FC<Props> = ({
           close={closeFailedRequestModal}
           proof={true}
         />
+      )}
+      {isDeclineModalOpen && (
+        <AnimatePresence>
+          <motion.div
+            variants={standardFade}
+            initial="hidden"
+            animate="show"
+            exit="exit"
+            className="fixed z-10 inset-0 overflow-y-auto"
+            aria-labelledby="modal-title"
+            role="dialog"
+            aria-modal="true"
+          >
+            <div className="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
+              <div
+                className="fixed inset-0 bg-bcgov-black bg-opacity-50 transition-all duration-300"
+                aria-hidden="true"
+                onClick={close}
+              />
+
+              <span className="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true" />
+
+              <motion.div
+                variants={dropIn}
+                initial="hidden"
+                animate="show"
+                exit="exit"
+                className="bg-bcgov-white dark:bg-bcgov-black inline-block align-bottom rounded-lg text-left overflow-hidden shadow-xl transform transition-all duration-300 sm:my-8 sm:align-middle sm:max-w-lg sm:w-full dark:text-white"
+              >
+                <div className=" px-4 pt-2 mt-4 sm:pb-4">
+                  <div className="sm:flex sm:items-start">
+                    <div className="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+                      <h2 className="text-xl font-medium text-grey-900">{'Proof request declined'}</h2>
+                      <div className="mt-2">
+                        <p className="text-sm">
+                          User has declined the proof request{' '}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div className="px-4 pb-4 sm:px-6 flex flex-row-reverse">
+                  <SmallButton onClick={() => setIsDeclineModalOpen(false)} text={'OK'} disabled={false} />
+                </div>
+              </motion.div>
+            </div>
+          </motion.div>
+        </AnimatePresence>
       )}
     </motion.div>
   )

--- a/apps/bc-wallet-showcase-creator/components/character-screen/characters.tsx
+++ b/apps/bc-wallet-showcase-creator/components/character-screen/characters.tsx
@@ -112,16 +112,16 @@ export default function NewCharacterPage({ slug }: { slug?: string }) {
   }, [selectedPersona, selectedPersonaId, form])
 
   useEffect(() => {
-    if (isLoading || !personasData?.personas || selectedPersonaId || initialSelectionDone) {
+    if (isLoading || selectedPersonaId || initialSelectionDone || !personasData) {
       return
     }
 
-    const filteredPersonas = personasData.personas.filter(onlyRecentlyCreated)
+    const filteredPersonas = (personasData.personas ?? []).filter(onlyRecentlyCreated)
 
     if (filteredPersonas.length > 0) {
       handlePersonaSelect(filteredPersonas[0])
       setInitialSelectionDone(true)
-    }else{
+    } else {
       handleCreateNew()
     }
   }, [
@@ -131,6 +131,7 @@ export default function NewCharacterPage({ slug }: { slug?: string }) {
     handlePersonaSelect,
     onlyRecentlyCreated,
     initialSelectionDone,
+    handleCreateNew,
   ])
 
   const handleFormSubmit = async (data: CharacterFormData) => {
@@ -297,6 +298,7 @@ export default function NewCharacterPage({ slug }: { slug?: string }) {
                   <StepHeader
                     icon={<Monitor strokeWidth={3} />}
                     title={t('character.character_detail')}
+                    showDropdown={personaState !== 'creating-new'}
                     deleteTitle='Delete character'
                     onActionClick={(action) => {
                       switch (action) {
@@ -376,22 +378,24 @@ export default function NewCharacterPage({ slug }: { slug?: string }) {
                                 text={t('character.headshot_image_label')}
                                 element={'headshot_image'}
                                 initialValue={
-                                  selectedPersona?.headshotImage?.id
+                                  personaState === 'creating-new' && headshotImage
+                                    ? `data:image/jpeg;base64,${headshotImage}`
+                                    : selectedPersona?.headshotImage?.id
                                     ? `${baseUrl}/${tenantId}/assets/${selectedPersona.headshotImage.id}/file`
                                     : undefined
                                 }
                                 maxSize={2 * 1024 * 1024} // 2MB limit
                                 onImageUploadError={handleImageUploadErrorHeadshot}
                                 handleJSONUpdate={(imageType, imageData, fileType) => {
-                                  setHeadshotImage(imageData);
+                                  setHeadshotImage(imageData)
                                   setHeadshotImageType(fileType ?? 'image/jpeg')
-                                  setIsHeadshotImageEdited(true);
-                                  setImageUploadErrorHeadshot(null); // Clear error on change
+                                  setIsHeadshotImageEdited(true)
+                                  setImageUploadErrorHeadshot(null) // Clear error on change
                                   setImageDirty(true)
                                 }}
                                 onImageDelete={() => {
-                                  handleImageDeletion('headshot');
-                                  setImageDirty(true);
+                                  handleImageDeletion('headshot')
+                                  setImageDirty(true)
                                 }}
                               />
                                {imageUploadErrorHeadshot && (
@@ -405,22 +409,24 @@ export default function NewCharacterPage({ slug }: { slug?: string }) {
                                 text={t('character.full_body_image_label')}
                                 element={'body_image'}
                                 initialValue={
-                                  selectedPersona?.bodyImage?.id
+                                  personaState === 'creating-new' && bodyImage
+                                    ? `data:image/jpeg;base64,${bodyImage}`
+                                    : selectedPersona?.bodyImage?.id
                                     ? `${baseUrl}/${tenantId}/assets/${selectedPersona.bodyImage.id}/file`
                                     : undefined
                                 }
                                 maxSize={2 * 1024 * 1024} // 2MB limit
                                 onImageUploadError={handleImageUploadError}
                                 handleJSONUpdate={(imageType, imageData, fileType) => {
-                                  setBodyImage(imageData);
+                                  setBodyImage(imageData)
                                   setBodyImageType(fileType ?? 'image/jpeg')
-                                  setIsBodyImageEdited(true);
-                                  setImageUploadError(null); // Clear error on change
+                                  setIsBodyImageEdited(true)
+                                  setImageUploadError(null) // Clear error on change
                                   setImageDirty(true)
                                 }}
                                 onImageDelete={() => {
-                                  handleImageDeletion('body');
-                                  setImageDirty(true);
+                                  handleImageDeletion('body')
+                                  setImageDirty(true)
                                 }}
                               />
                               {imageUploadError && (

--- a/apps/bc-wallet-showcase-creator/components/credentials/credentials-form.tsx
+++ b/apps/bc-wallet-showcase-creator/components/credentials/credentials-form.tsx
@@ -553,8 +553,7 @@ export const CredentialsForm = () => {
               ⚠️ <span className="font-semibold">Credentials cannot be edited once created. </span>
               If changes are needed <span className="font-semibold">create a new version.</span>
               <br />
-              📝 <span className="font-semibold">Attribute values are defined during scenario</span> creation in the{' '}
-              <span className="font-semibold">Onboarding</span> step.
+              📝 <span className="font-semibold">Attributes values are defined in the Onboarding menu.</span>
             </p>
           </div>
         </div>

--- a/apps/bc-wallet-showcase-creator/components/onboarding-screen/create-step.tsx
+++ b/apps/bc-wallet-showcase-creator/components/onboarding-screen/create-step.tsx
@@ -112,27 +112,6 @@ export const CreateNewStep = () => {
         onClick={() => handleAddStep('issue')}
       />
 
-      <StepButton
-        title={t('onboarding.install_wallet_step_label') || 'Install Wallet Step'}
-        details={[
-          t('onboarding.create_title_label') || 'Title',
-          t('onboarding.create_description_label') || 'Description',
-          t('onboarding.create_image_label') || 'Image',
-          t('onboarding.install_wallet_label') || 'Wallet',
-        ]}
-        onClick={() => handleAddStep('wallet')}
-      />
-
-      <StepButton
-        title={t('onboarding.connect_step_label') || 'Connect Step'}
-        details={[
-          t('onboarding.create_title_label') || 'Title',
-          t('onboarding.create_description_label') || 'Description',
-          t('onboarding.create_image_label') || 'Image',
-          'QR Code',
-        ]}
-        onClick={() => handleAddStep('connect')}
-      />
     </>
   )
 }

--- a/apps/bc-wallet-showcase-creator/components/onboarding-screen/display-added-credentials.tsx
+++ b/apps/bc-wallet-showcase-creator/components/onboarding-screen/display-added-credentials.tsx
@@ -12,6 +12,7 @@ import { useCredentialDefinition } from '@/hooks/use-credentials'
 import type { CredentialSchemaRequest, CredentialAttribute } from 'bc-wallet-openapi'
 import { Skeleton } from '../ui/skeleton'
 import { useTenant } from '@/providers/tenant-provider'
+import { toast } from 'sonner'
 
 interface DisplayCredentialProps {
   credentialId: string
@@ -58,6 +59,15 @@ export const DisplayCredential = ({ credentialId, removeCredential, onCredential
   const handleSaveAttributes = async () => {
     if (!data || !data.credentialDefinition || !data.credentialDefinition.credentialSchema) {
       console.error('Missing credential schema data')
+      return
+    }
+
+    const dateValidationErrors = credentialAttributes
+      .filter((attr) => attr.type === 'DATE' && attr.value && attr.value.length !== 8)
+      .map((attr) => `• ${attr.name}: must be exactly 8 digits (YYYYMMDD).`)
+
+    if (dateValidationErrors.length > 0) {
+      toast.error(`Invalid attribute value(s):${dateValidationErrors.join('')}`, { duration: 3000 })
       return
     }
 

--- a/apps/bc-wallet-showcase-creator/components/onboarding-screen/step-editor-form.tsx
+++ b/apps/bc-wallet-showcase-creator/components/onboarding-screen/step-editor-form.tsx
@@ -6,8 +6,6 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { Monitor } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import { toast } from 'sonner'
-import { useRouter } from '@/i18n/routing'
-import { useTenant } from '@/providers/tenant-provider'
 import { Form } from '@/components/ui/form'
 import { FormTextArea, FormTextInput } from '@/components/text-input'
 import { LocalFileUpload } from './local-file-upload'
@@ -35,6 +33,8 @@ import { StepActionRequestUnion } from '@/types'
 import { useOnboardingAdapter } from '@/hooks/use-onboarding-adapter'
 import DeleteModal from '../delete-modal'
 import { useFormDirtyStore } from '@/hooks/use-form-dirty-store'
+import { useTenant } from '@/providers/tenant-provider'
+import { useRouter } from '@/i18n/routing'
 interface StepEditorFormProps {
   currentStep: StepRequest | null
   stepType: StepType
@@ -44,9 +44,8 @@ interface StepEditorFormProps {
   onCancel: () => void
   toggleViewMode: () => void
   isEditMode?: boolean
-  onProceed: () => void
-  updateScenarios?: (slug: string) => Promise<any>
-  createScenarios?: () => Promise<any>
+  showcaseSlug?: string
+  isUpdated?: boolean
 }
 
 export const StepEditorForm: React.FC<StepEditorFormProps> = ({
@@ -57,17 +56,14 @@ export const StepEditorForm: React.FC<StepEditorFormProps> = ({
   onSubmit,
   onCancel,
   toggleViewMode,
+  showcaseSlug,
   isEditMode = false,
-  onProceed,
-  updateScenarios: propUpdateScenarios,
-  createScenarios: propCreateScenarios
+  isUpdated
 }) => {
   const t = useTranslations()
-  const router = useRouter()
-  const { tenantId } = useTenant()
   const [isModalOpen, setIsModalOpen] = useState(false)
-  const [isSaving, setIsSaving] = useState(false)
-  const { setDirty, isDirty } = useFormDirtyStore()
+  const { tenantId } = useTenant();
+  const router = useRouter()
   
   const getCurrentAction = (): StepActionRequestUnion | null => {
     if (!currentStep || !currentStep.actions || currentStep.actions.length === 0) {
@@ -78,8 +74,6 @@ export const StepEditorForm: React.FC<StepEditorFormProps> = ({
 
   const currentAction = getCurrentAction();
   const { deleteStep, selectedScenario, personaScenarios } = useOnboardingAdapter()
-
-  // console.log('selectedScenario',selectedScenario);
 
 const isInvalidServiceStep = Array.from(personaScenarios).some(([_, scenarioList]) =>
   scenarioList.some((scenario) =>
@@ -196,19 +190,12 @@ const isInvalidServiceStep = Array.from(personaScenarios).some(([_, scenarioList
   useEffect(() => {
     if (currentStep) {
       form.reset(getDefaultValues())
-      setDirty(false)
     }
-  }, [currentStep, setDirty])
+  }, [currentStep])
 
   const autoSave = debounce((data: FormData) => {
     if (!currentStep || !form.formState.isDirty || !selectedStep) return;
   
-    performSave(data);
-  }, 800);
-
-  const performSave = (data: FormData) => {
-    if (!currentStep || !selectedStep) return;
-
     const updatedStep: StepRequest = {
       ...currentStep,
       title: data.title,
@@ -277,87 +264,10 @@ const isInvalidServiceStep = Array.from(personaScenarios).some(([_, scenarioList
   
     setTimeout(() => {
       toast.success('Changes saved', { duration: 1000 });
-      setDirty(false)
     }, 500);
-  };
+  }, 800);
 
   useEffect(() => {
-    const subscription = form.watch((value, { name, type }) => {
-      if (name && type === 'change') {
-        setDirty(true);
-      }
-    })
-    return () => subscription.unsubscribe()
-  }, [form, setDirty])
-
-  const handleSave = async () => {
-    if (!form.formState.isValid) {
-      toast.error(t('onboarding.form_validation_error'));
-      return;
-    }
-    
-    setIsSaving(true);
-    
-    try {
-      // First save to local state
-      form.handleSubmit(performSave)();
-      
-      // Wait a bit for state to update
-      await new Promise(resolve => setTimeout(resolve, 200));
-        console.log('isEditMode',isEditMode);
-      // Then save to API using passed methods
-      if (isEditMode && propUpdateScenarios) {
-        // Update existing scenario
-        // @ts-expect-error : Slug is available
-        const result = await propUpdateScenarios(selectedScenario.slug);
-        console.log('result',result);
-        if (result.success) {
-          toast.success('Changes saved successfully');
-        } else {
-          toast.error(result.message || 'Error saving changes');
-        }
-      } else if (propCreateScenarios) {
-        // Create new scenario
-        const result = await propCreateScenarios();
-        if (result.success) {
-          toast.success('Scenario created successfully');
-        } else {
-          toast.error(result.message || 'Error creating scenario');
-        }
-      } else {
-        // Just save locally if no API methods provided
-        toast.success('Changes saved locally');
-      }
-    } catch (error) {
-      console.error('Error saving step:', error);
-      toast.error('Error saving changes');
-    } finally {
-      setIsSaving(false);
-    }
-  };
-
-  const handleProceedToScenario = () => {
-    if (isDirty) {
-      toast.warning(t('character.save_changes_warning'));
-      return;
-    }
-    
-    // Navigate to scenario page directly
-    try {
-      // @ts-expect-error : Slug is available
-      if (isEditMode && selectedScenario?.slug) {
-        // @ts-expect-error : Slug is available
-        router.push(`/${tenantId}/showcases/${selectedScenario.slug}/scenarios`);
-      } else {
-        router.push(`/${tenantId}/showcases/create/scenarios`);
-      }
-    } catch (error) {
-      console.error('Error navigating to scenarios:', error);
-      toast.error('Error navigating');
-    }
-  };
-
-   useEffect(() => {
     const subscription = form.watch((value) => {
       if (form.formState.isDirty) {
         autoSave(value as FormData)
@@ -453,6 +363,15 @@ const isInvalidServiceStep = Array.from(personaScenarios).some(([_, scenarioList
     }
     
     updateStep(selectedStep.order, updatedStep);
+  }
+
+  const GotoNext = () => {
+  if (isEditMode && showcaseSlug) {
+        // result = await updateScenarios(showcaseSlug)
+        router.push(`/${tenantId}/showcases/${showcaseSlug}/scenarios`)
+      } else {
+        router.push(`/${tenantId}/showcases/create/scenarios`)
+      }
   }
 
   return (
@@ -636,31 +555,31 @@ const isInvalidServiceStep = Array.from(personaScenarios).some(([_, scenarioList
           )}
         </div>
 
-
-        <div className="gap-3 flex justify-between">
-          <ButtonOutline onClick={() => {
-            if (isDirty) {
-              toast.warning(t('character.save_changes_warning'))
-              return
-            }
-            onCancel()
-          }} type="button">
+        <div className="mt-auto pt-4 border-t flex justify-between gap-3">
+          <ButtonOutline onClick={onCancel} type="button">
             {'Help'}
           </ButtonOutline>
 
+<div className='gap-4 flex'>
 
-
-          <div className='flex gap-3'>
           <ButtonOutline
             type="button"
             onClick={() => form.handleSubmit(onSubmit)()}
-            disabled={!form.formState.isValid || currentStep?.actions[0]?.credentialDefinitionId === '' || isInvalidServiceStep}
+            disabled={!form.formState.isValid}
+          >
+            {'Save'}
+          </ButtonOutline>
+
+          <ButtonOutline
+            type="button"
+            onClick={() => GotoNext()}
+            disabled={!isUpdated}
+            // disabled={!form.formState.isValid || currentStep?.actions[0]?.credentialDefinitionId === '' || isInvalidServiceStep}
           >
             {'Proceed to Scenario'}
           </ButtonOutline>
-          </div>
-
-          </div>
+</div>
+        </div>
       </form>
     </Form>
     <DeleteModal

--- a/apps/bc-wallet-showcase-creator/components/onboarding-screen/step-editor.tsx
+++ b/apps/bc-wallet-showcase-creator/components/onboarding-screen/step-editor.tsx
@@ -16,6 +16,7 @@ import { useShowcase } from '@/hooks/use-showcases'
 import { useTenant } from '@/providers/tenant-provider'
 import { useFormDirtyStore } from '@/hooks/use-form-dirty-store'
 import { useBeforeUnload } from '@/hooks/use-before-unload'
+import { useShowcaseStore } from '@/hooks/use-showcases-store'
 
 export const StepEditor = ({ showcaseSlug }: { showcaseSlug?: string }) => {
   const t = useTranslations()
@@ -24,7 +25,9 @@ export const StepEditor = ({ showcaseSlug }: { showcaseSlug?: string }) => {
   const [showErrorModal, setErrorModal] = useState(false)
   const [errorMessage, setErrorMessage] = useState('')
   const [isViewMode, setIsViewMode] = useState(false)
+  const [isUpdated, setIsUpdated] = useState(false)
   const { data: showcaseData, isLoading: isShowcaseLoading } = useShowcase(showcaseSlug || '')
+  const { currentShowcaseSlug } = useShowcaseStore()
   const { isDirty } = useFormDirtyStore()
   useBeforeUnload(isDirty, t('character.save_changes_warning'))
 
@@ -37,7 +40,7 @@ export const StepEditor = ({ showcaseSlug }: { showcaseSlug?: string }) => {
     createScenarios,
     updateScenarios,
     isEditMode
-  } = useOnboardingAdapter(showcaseSlug)
+  } = useOnboardingAdapter(currentShowcaseSlug)
   const { tenantId } = useTenant();
 
   const currentStep = selectedStep !== null ? screens[selectedStep.order] : null
@@ -60,11 +63,12 @@ export const StepEditor = ({ showcaseSlug }: { showcaseSlug?: string }) => {
     try {
       let result;
 
-      if (isEditMode && showcaseSlug) {
-        result = await updateScenarios(showcaseSlug)
+      if (isEditMode && currentShowcaseSlug) {
+        result = await updateScenarios(currentShowcaseSlug)
         if (result.success) {
           toast.success('Scenarios updated successfully')
-          router.push(`/${tenantId}/showcases/${showcaseSlug}/scenarios`)
+          setIsUpdated(true)
+          // router.push(`/${tenantId}/showcases/${showcaseSlug}/scenarios`)
         } else {
           throw new Error(result.message || 'Failed to update scenarios')
         }
@@ -72,7 +76,8 @@ export const StepEditor = ({ showcaseSlug }: { showcaseSlug?: string }) => {
         result = await createScenarios()
         if (result.success) {
           toast.success('Scenarios created successfully')
-          router.push(`/${tenantId}/showcases/create/scenarios`)
+          setIsUpdated(true)
+          // router.push(`/${tenantId}/showcases/create/scenarios`)
         } else {
           throw new Error(result.message || 'Failed to create scenarios')
         }
@@ -119,10 +124,8 @@ export const StepEditor = ({ showcaseSlug }: { showcaseSlug?: string }) => {
       onCancel={handleCancel}
       toggleViewMode={toggleViewMode}
       isEditMode={isEditMode}
-      onProceed={handleSubmit}
-      updateScenarios={updateScenarios}
-      createScenarios={createScenarios}
-      // showcaseSlug={showcaseSlug}
+      showcaseSlug={currentShowcaseSlug}
+      isUpdated={isUpdated}
     />
   )
 }

--- a/apps/bc-wallet-showcase-creator/components/publish-screen/publish-edit.tsx
+++ b/apps/bc-wallet-showcase-creator/components/publish-screen/publish-edit.tsx
@@ -15,7 +15,7 @@ import StepHeader from '../step-header'
 import ButtonOutline from '../ui/button-outline'
 import { toast } from 'sonner'
 import Image from 'next/image'
-import { ShowcaseRequest, ShowcaseStatus, AssetResponse } from 'bc-wallet-openapi'
+import { ShowcaseRequest, ShowcaseStatus, AssetResponse, IssuanceScenario, PresentationScenario, Showcase } from 'bc-wallet-openapi'
 import { z } from 'zod'
 
 import { ConfirmationDialog } from '@/components/confirmation-dialog'
@@ -24,6 +24,7 @@ import { useShowcaseAdapter } from '@/hooks/use-showcase-adapter'
 import { useTenant } from '@/providers/tenant-provider'
 import { usePresentationCreation } from '@/hooks/use-presentation-creation'
 import { useOnboardingCreationStore } from '@/hooks/use-onboarding-store'
+import { useShowcase } from '@/hooks/use-showcases'
 
 const BannerImageUpload = ({
   text,
@@ -134,8 +135,10 @@ const BannerImageUpload = ({
 }
 
 const ShowcaseRequestSchema = z.object({
-  name: z.string().min(1),
-  description: z.string().min(1),
+  name: z.string().min(1, 'Showcase name is required'),
+  description: z.string().min(1, 'Showcase description is required'),
+  bannerImage: z.string().min(1, 'Banner image is required'),
+  completionMessage: z.string().optional(),
   status: z.nativeEnum(ShowcaseStatus),
   hidden: z.boolean(),
   tenantId: z.string().min(1),
@@ -150,12 +153,23 @@ export const PublishEdit = () => {
   const { tenantId } = useTenant();
   const resetIds = usePresentationCreation().reset
   const resetOnboardingIds = useOnboardingCreationStore().reset
+  //@ts-expect-error: Slug is present
+  let Slug = showcase?.slug
+  const { data: showcaseDataFull, isLoading: isShowcaseLoading } = useShowcase(Slug || '')
 
   const [imageUploadError, setImageUploadError] = useState<string | null>(null);
+  const [FullShowcaseData,setFullShowcaseData] = useState<any | null>(null) 
+  const [showErrorModal, setShowErrorModal] = useState(false)
+  const [errorMessages, setErrorMessages] = useState<string[]>([])
   
   const handleImageUploadError = (error: string) => {
     setImageUploadError(error);
   };
+
+  const closeErrorModal = () => {
+    setShowErrorModal(false)
+    setErrorMessages([])
+  }
 
   const form = useForm<ShowcaseRequest>({
     resolver: zodResolver(ShowcaseRequestSchema),
@@ -167,7 +181,10 @@ export const PublishEdit = () => {
       scenarios: [],
       personas: [],
       tenantId,
+      bannerImage: '',
+      completionMessage: '',
     },
+    mode: 'onChange',
   })
 
   useEffect(() => {
@@ -189,16 +206,103 @@ export const PublishEdit = () => {
     })
   }, [form.reset, showcase, tenantId, JSON.stringify(personas)])
 
+  useEffect(() => {
+    setFullShowcaseData(showcaseDataFull?.showcase)
+  },[showcase,Slug])
+  
+
   const onSubmit = async () => {
-    const data = form.getValues()
-    await saveShowcase(data)
-    toast.success('Showcase created successfully')
-    reset()
-    setScenarioIds([])
-    setPersonaIds([])
-    resetIds()
-    resetOnboardingIds()
-    router.push(`/${tenantId}/showcases`)
+  const data = form.getValues()
+  if (!FullShowcaseData) return
+
+  const missing: string[] = []
+  const personas = FullShowcaseData.personas || []
+  const scenarios = FullShowcaseData.scenarios || []
+
+
+  if (personas.length < 1) {
+    missing.push('At least 1 persona is required')
+  }
+
+
+  const issuanceScenarios = scenarios.filter((s:IssuanceScenario) => s.type === 'ISSUANCE')
+  const presentationScenarios = scenarios.filter((s:PresentationScenario) => s.type === 'PRESENTATION')
+  const requiredScenarios = personas.length * 2 // 1 ISSUANCE + 1 PRESENTATION per persona
+
+  if (scenarios.length < requiredScenarios) {
+    missing.push(`At least ${requiredScenarios} scenarios required (currently ${scenarios.length})`)
+  }
+
+  if (issuanceScenarios.length < personas.length) {
+    missing.push(`At least ${personas.length} issuance scenario(s) required (currently ${issuanceScenarios.length})`)
+  }
+
+  if (presentationScenarios.length < personas.length) {
+    missing.push(`At least ${personas.length} presentation scenario(s) required (currently ${presentationScenarios.length})`)
+  }
+
+
+  issuanceScenarios.forEach((scenario: IssuanceScenario) => {
+    if ((scenario.steps || []).length < 6) {
+      missing.push(`Issuance scenario "${scenario.name}" must have at least 6 steps (currently ${(scenario.steps || []).length})`)
+    }
+
+
+    scenario.steps?.forEach((step) => {
+      if (step.type === 'SERVICE') {
+        step.actions?.forEach((action) => {
+          if (action.actionType === 'ACCEPT_CREDENTIAL') {
+            if (!('credentialDefinitionId' in action) || !action.credentialDefinitionId || action.credentialDefinitionId.trim() === '') {
+              missing.push(
+                `Step "${step.title}" in scenario "${scenario.name}" must have a valid credentialDefinitionId for ACCEPT_CREDENTIAL action`
+              )
+            }
+          }
+        })
+      }
+    })
+  })
+
+  
+
+  presentationScenarios.forEach((scenario: PresentationScenario) => {
+    if ((scenario.steps || []).length < 3) {
+      missing.push(`Presentation scenario "${scenario.name}" must have at least 3 steps (currently ${(scenario.steps || []).length})`)
+    }
+
+    scenario.steps?.forEach((step) => {
+      if (step.type === 'SERVICE') {
+        step.actions?.forEach((action) => {
+          //@ts-expect-error : proof request exists
+          const proofRequest = action?.proofRequest
+          if (!proofRequest) {
+            missing.push(`Step "${step.title}" in scenario "${scenario.name}" must have a proofRequest`)
+          } else {
+            const hasAttributes = Object.keys(proofRequest.attributes || {}).length > 0
+            const hasPredicates = Object.keys(proofRequest.predicates || {}).length > 0
+            if (!hasAttributes && !hasPredicates) {
+              missing.push(`ProofRequest in step "${step.title}" of scenario "${scenario.name}" must contain at least one attribute or predicate`)
+            }
+          }
+        })
+      }
+    })
+  })
+  console.log('missing',missing);
+  if (missing.length > 0) {
+    setErrorMessages(missing)
+    setShowErrorModal(true)
+    return
+  }
+
+  await saveShowcase(data)
+  toast.success('Showcase created successfully')
+  reset()
+  setScenarioIds([])
+  setPersonaIds([])
+  resetIds()
+  resetOnboardingIds()
+  router.push(`/${tenantId}/showcases`)
   }
 
   const handleCancel = () => {
@@ -260,6 +364,11 @@ export const PublishEdit = () => {
                   {imageUploadError}
                 </p>
               )}
+              {form.formState.errors.bannerImage && (
+                <p className="text-md w-full text-start text-foreground mb-3 text-red-500 text-sm">
+                  {form.formState.errors.bannerImage.message}
+                </p>
+              )}
             </div>
           </div>
 
@@ -276,11 +385,43 @@ export const PublishEdit = () => {
                 }
                 buttonLabel={t('showcase.button_label')}
                 onSubmit={onSubmit}
+                disabled={!form.formState.isValid}
               />
             </div>
           </div>
         </form>
       </Form>
+{
+  showErrorModal && (
+    <>
+     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80">
+      <div className="relative w-full max-w-lg rounded-lg bg-background p-6 shadow-lg">
+        <div className="flex flex-col space-y-1.5 text-center sm:text-left">
+          <h2 className="text-lg font-semibold leading-none tracking-tight">
+            {'Please correct the following issues to proceed:'}
+          </h2>
+        </div>
+        <div className="py-4">
+          <ul className="list-disc pl-5 text-red-500">
+            {errorMessages.map((error, index) => (
+              <li key={index}>{error}</li>
+            ))}
+          </ul>
+        </div>
+        <div className="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2">
+          <button
+            type="button"
+            onClick={closeErrorModal}
+            className="inline-flex h-10 items-center justify-center whitespace-nowrap rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground ring-offset-background transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
+          >
+            {'Close'}
+          </button>
+        </div>
+      </div>
+    </div>
+    </>
+  )
+}
     </div>
   )
 }

--- a/apps/bc-wallet-showcase-creator/components/scenario-screen/basic-step-edit.tsx
+++ b/apps/bc-wallet-showcase-creator/components/scenario-screen/basic-step-edit.tsx
@@ -42,6 +42,7 @@ export const BasicStepEdit = ({ slug }: { slug?: string }) => {
   const { tenantId } = useTenant();
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [showErrorModal, setErrorModal] = useState(false)
+  const [isUpdated, setIsUpdated] = useState(false)
 
 const isInvalidServiceStep = Array.from(personaScenarios).some(([_, scenarioList]) =>
   scenarioList.some((scenario) =>
@@ -144,7 +145,15 @@ const isInvalidServiceStep = Array.from(personaScenarios).some(([_, scenarioList
     if (!currentStep) return;
 
     const { credentialDefinitionId, ...cleanedAction } = currentStep.actions[0];
-    const updatedActions = [cleanedAction];
+     const updatedAction = {
+        ...cleanedAction,
+        proofRequest: {
+          attributes: {},
+          predicates: {},
+        },
+      }
+
+    const updatedActions = [updatedAction];
 
     updateStep(selectedStep?.stepIndex || 0, { ...currentStep, actions: updatedActions } as unknown as StepRequestUIActionTypes);
     setSelectedCredential(null);
@@ -160,7 +169,8 @@ const isInvalidServiceStep = Array.from(personaScenarios).some(([_, scenarioList
 
         if (result.success) {
           toast.success('Scenarios updated successfully')
-          router.push(`/${tenantId}/showcases/${slug}/publish`)
+          setIsUpdated(true)
+          // router.push(`/${tenantId}/showcases/${slug}/publish`)
         } else {
           throw new Error(result.message || 'Failed to update scenarios')
         }
@@ -169,7 +179,8 @@ const isInvalidServiceStep = Array.from(personaScenarios).some(([_, scenarioList
 
         if (result.success) {
           toast.success('Scenarios created successfully')
-          router.push(`/${tenantId}/showcases/create/publish`)
+          setIsUpdated(true)
+          // router.push(`/${tenantId}/showcases/create/publish`)
         } else {
           throw new Error(result.message || 'Failed to create scenarios')
         }
@@ -180,6 +191,14 @@ const isInvalidServiceStep = Array.from(personaScenarios).some(([_, scenarioList
     }
   }
 
+  const GoToNext = () => {
+    if (isEditMode && slug) {
+      router.push(`/${tenantId}/showcases/${slug}/publish`)
+    } else {
+      router.push(`/${tenantId}/showcases/create/publish`)
+    }
+  }
+
   if (!currentStep) return null
 
   if (showErrorModal) {
@@ -187,10 +206,42 @@ const isInvalidServiceStep = Array.from(personaScenarios).some(([_, scenarioList
   }
 
   const action = currentStep?.actions?.[0];
-  const isProofRequestEmpty =
-  action?.proofRequest && currentStep.type === StepType.Service &&
-  Object.keys(action.proofRequest.attributes || {}).length === 0 &&
-  Object.keys(action.proofRequest.predicates || {}).length === 0;
+
+  // Extended validation for predicates (same as onSubmit)
+  const hasInvalidPredicates =
+    action?.proofRequest &&
+    currentStep.type === StepType.Service &&
+    Object.values(action.proofRequest.predicates || {}).some((predGroup: any) =>
+      (predGroup.predicates || []).some(
+        (p: any) =>
+          (p.type === '>=' || p.type === '<=') &&
+          (String(p.value) === '0' || !/^\d{8}$/.test(String(p.value)))
+      )
+    )
+
+  // Extended validation for attributes/predicates existence
+  const hasNoAttributesOrPredicates =
+    action?.proofRequest &&
+    currentStep.type === StepType.Service &&
+    Object.values(action.proofRequest.attributes || {}).every(
+      (attrGroup: any) => !attrGroup.attributes || attrGroup.attributes.length === 0
+    ) &&
+    Object.values(action.proofRequest.predicates || {}).every(
+      (predGroup: any) => !predGroup.predicates || predGroup.predicates.length === 0
+    )
+
+    console.log('Test',action?.proofRequest);
+
+    console.log('hasNoAttributesOrPredicates', hasNoAttributesOrPredicates);
+    console.log('hasInvalidPredicates', hasInvalidPredicates);
+
+    const isProofRequestEmpty =
+    action?.proofRequest && currentStep.type === StepType.Service &&
+    Object.keys(action.proofRequest.attributes || {}).length === 0 &&
+    Object.keys(action.proofRequest.predicates || {}).length === 0;
+
+    const isProofRequestInvalid = isProofRequestEmpty || hasNoAttributesOrPredicates || hasInvalidPredicates
+
 
   const getInstructionalText = () => {
         if (currentStep?.order === 0) {
@@ -221,6 +272,7 @@ const isInvalidServiceStep = Array.from(personaScenarios).some(([_, scenarioList
       <StepHeader
         icon={<Monitor strokeWidth={3} />}
         deleteTitle='Delete step'
+        showDropdown={(currentStep?.order ?? 0) >= 3}
         title={getStepTitle()}
         onActionClick={(action) => {
           switch (action) {
@@ -334,12 +386,23 @@ const isInvalidServiceStep = Array.from(personaScenarios).some(([_, scenarioList
           <div className="mt-auto pt-4 border-t flex justify-between ">
             <ButtonOutline onClick={() => setStepState('no-selection')}>{'help'}</ButtonOutline>
 
-            <ButtonOutline type="submit" 
-              disabled={!form.formState.isValid || isProofRequestEmpty || isInvalidServiceStep}
+          <div className='flex gap-4'>
+
+            <ButtonOutline type="button" 
+              disabled={!form.formState.isValid}
               onClick={form.handleSubmit(onSubmit)}
+            >
+              {'Save'}
+            </ButtonOutline>
+
+            <ButtonOutline type="button" 
+              disabled={!isUpdated}
+              // disabled={!form.formState.isValid || isProofRequestInvalid || isInvalidServiceStep}
+              onClick={() => GoToNext()}
             >
               {'Proceed to Publish'}
             </ButtonOutline>
+          </div>
 
           </div>
         </form>

--- a/apps/bc-wallet-showcase-creator/components/scenario-screen/edit-proof-request.tsx
+++ b/apps/bc-wallet-showcase-creator/components/scenario-screen/edit-proof-request.tsx
@@ -273,6 +273,32 @@ export const EditProofRequest = ({
 
     const formData = form.getValues()
 
+      const attributesForCred = formData.attributes?.[credentialName]?.attributes || []
+      const predicatesForCred = formData.predicates?.[credentialName]?.predicates || []
+
+      if ((!attributesForCred || attributesForCred.length === 0) && (!predicatesForCred || predicatesForCred.length === 0)) {
+        toast.error(`You must add at least one attribute or one predicate for credential "${credentialName || 'unknown'}"`)
+        return
+      }
+
+      // Validation: Predicates with >= or <= must have a valid 8-digit value
+      const errorMessages: string[] = [];
+      predicatesForCred.forEach((p) => {
+        if (p.type === '>=' || p.type === '<=') {
+          const valueStr = String(p.value);
+          // Check if the value is not exactly 8 digits or is the default '0'
+          if (!/^\d{8}$/.test(valueStr) || valueStr === '0') {
+            errorMessages.push(`• ${p.name}: Condition Value must be exactly 8 digits (YYYYMMDD).`);
+          }
+        }
+      });
+
+      if (errorMessages.length > 0) {
+        toast.error(
+          `Invalid predicate value(s) for credential "${credentialName}":` +errorMessages.join(''),{ duration: 3000 });
+        return;
+      }
+
     // setEditingCredentials(editingCredentials.filter((i) => i !== editingIndex))
 
     const updatedStep: StepRequest = {

--- a/apps/bc-wallet-showcase-creator/components/scenario-screen/proof-attribute.tsx
+++ b/apps/bc-wallet-showcase-creator/components/scenario-screen/proof-attribute.tsx
@@ -79,10 +79,17 @@ export const ProofAttribute = ({
       </div>
 
       <div className="space-y-2">
+        <div className='flex flex-col'>
         <label className="text-sm font-medium">Condition Value</label>
+        {attribute.type === 'DATE' ? <div className='text-xs text-red-500'>Date format: YYYYMMDD</div> : ''}
+        </div>
         <Input
-          onChange={(e) => onConditionValueChange(index, e.target.value)}
-          disabled={attribute.type !== 'DATE'}
+          onChange={(e) => {
+            if (e.target.value.length <= 8) {
+              onConditionValueChange(index, e.target.value)
+            }
+          }}
+          disabled={attribute.type !== 'DATE' || (predicates?.find(p => p.name === attribute.name)?.type || 'none') === 'none'}
           type="number"
           value={predicates?.find(p => p.name === attribute.name)?.value || ''}
         />

--- a/apps/bc-wallet-showcase-creator/components/scenario-screen/scenario-creation.tsx
+++ b/apps/bc-wallet-showcase-creator/components/scenario-screen/scenario-creation.tsx
@@ -217,7 +217,7 @@ export const CreateScenariosScreen = () => {
                       >
                         {t('onboarding.add_step_label')}
                       </Button>
-
+                      {scenarios.length > 1 && (   
                       <Button
                         onClick={() => handleScenarioDelete(index)}
                         variant="outlineAction"
@@ -225,6 +225,7 @@ export const CreateScenariosScreen = () => {
                       >
                         {t('scenario.remove_scenario_label').toUpperCase()}
                       </Button>
+                      )}
                     </div>
                   </>
                   {/* )} */}

--- a/apps/bc-wallet-showcase-creator/components/scenario-screen/scenario-edit.tsx
+++ b/apps/bc-wallet-showcase-creator/components/scenario-screen/scenario-edit.tsx
@@ -61,7 +61,7 @@ export const ScenarioEdit = ({ slug }: { slug?: string }) => {
         name:data.name,
         description: data.description
       }
-
+      //@ts-ignore
       updateScenario(updatedScenario)
     setStepState('no-selection')
   }

--- a/apps/bc-wallet-showcase-creator/hooks/use-onboarding-adapter.tsx
+++ b/apps/bc-wallet-showcase-creator/hooks/use-onboarding-adapter.tsx
@@ -392,6 +392,7 @@ export const useOnboardingAdapter = (showcaseSlug?: string) => {
 
           if (result && result.issuanceScenario) {
             scenarioIds.push(result.issuanceScenario.id);
+            toast.success(`Onboarding created for ${scenario.personas[0] ? selectedPersonas.find(p => p.id === scenario.personas[0])?.name || 'persona' : 'persona'}`);
             
             // Update the scenario with the returned slug to prevent duplicate creation
             if (result.issuanceScenario.slug && scenario.personas && scenario.personas.length > 0) {
@@ -409,7 +410,6 @@ export const useOnboardingAdapter = (showcaseSlug?: string) => {
               );
               
               if (scenarioIndex >= 0) {
-                //@ts-expect-error: Slug is available
                 updateScenario(personaId, scenarioIndex, {
                   ...scenario,
                   //@ts-ignore
@@ -418,8 +418,6 @@ export const useOnboardingAdapter = (showcaseSlug?: string) => {
                 });
               }
             }
-            
-            toast.success(`Onboarding created successfully for ${scenario.personas[0] ? selectedPersonas.find(p => p.id === scenario.personas[0])?.name || 'persona' : 'persona'}`);
           } else {
             throw new Error('Invalid response format');
           }
@@ -492,12 +490,20 @@ export const useOnboardingAdapter = (showcaseSlug?: string) => {
 
       for (const scenario of personaScenariosList) {
         if (!scenario) continue;
-        
-        // Only update scenarios that already exist (have slugs)
+        let result;
         //@ts-ignore
-        if (scenario.slug) {
+        if(!scenario.slug) {
+          debugLog('Scenario slug is required for update:', scenario);
+          result = await createScenarios([scenario])
+          if (result && result.success) {
+            toast.success('Scenarios created successfully')
+            // router.push(`/${tenantId}/showcases/create/scenarios`)
+          } else {
+            throw new Error('Invalid response format');
+          }
+        } else{
           try {
-            const result = await updateScenarioAsync({
+            result = await updateScenarioAsync({
               // @ts-expect-error: slug is not required
               slug: scenario.slug,
               data: scenario
@@ -515,9 +521,6 @@ export const useOnboardingAdapter = (showcaseSlug?: string) => {
           } catch (error) {
             return { success: false, message: 'Error updating scenario', error };
           }
-        } else {
-          // Scenario doesn't exist yet, skip it for update operation
-          debugLog('Skipping scenario without slug in update operation:', scenario);
         }
       }
 

--- a/apps/bc-wallet-showcase-creator/hooks/use-onboarding-creation.ts
+++ b/apps/bc-wallet-showcase-creator/hooks/use-onboarding-creation.ts
@@ -179,8 +179,7 @@ export const useOnboardingCreation = (showcaseSlug?: string) => {
     setStepState,
     stepState,
     selectedScenario,
-    updateScenario: (scenarioData: IssuanceScenarioRequest) =>
-      activePersonaId && updateScenario(activePersonaId, activeScenarioIndex, scenarioData),
+    updateScenario,
     removeScenario: () => activePersonaId && removeScenario(activePersonaId, activeScenarioIndex),
     selectedStep,
     setSelectedStep,

--- a/apps/bc-wallet-showcase-creator/hooks/use-onboarding-store.ts
+++ b/apps/bc-wallet-showcase-creator/hooks/use-onboarding-store.ts
@@ -51,6 +51,7 @@ interface OnboardingCreationState {
   removeScenario: (personaId: string, scenarioIndex: number) => void
   setSelectedStep: (selectedStep: Screen | null) => void
   selectStep: (stepIndex: number, scenarioIndex: number) => void
+  setPersonaScenariosMap: (scenariosMap: Record<string, IssuanceScenarioRequest[]>) => void
 
   reset: () => void
 }
@@ -466,6 +467,11 @@ export const useOnboardingCreationStore = create<OnboardingCreationState>()(
         } else {
           state.stepState = 'editing-basic'
         }
+      }),
+
+    setPersonaScenariosMap: (scenariosMap) =>
+      set((state) => {
+        state.personaScenariosMap = scenariosMap
       }),
 
     reset: () =>

--- a/apps/bc-wallet-showcase-creator/hooks/use-persona-adapter.ts
+++ b/apps/bc-wallet-showcase-creator/hooks/use-persona-adapter.ts
@@ -1,14 +1,14 @@
-import { useState, useCallback, useEffect, useMemo } from "react";
-import { useShowcaseStore } from "@/hooks/use-showcases-store";
-import { usePersonas, useCreatePersona, useUpdatePersona, useDeletePersona } from '@/hooks/use-personas';
-import { useCreateAsset } from '@/hooks/use-asset';
-import { usePersonaStore } from '@/hooks/use-persona-store';
+import { useState, useCallback, useEffect } from 'react'
+import { useShowcaseStore } from '@/hooks/use-showcases-store'
+import { usePersonas, useCreatePersona, useUpdatePersona, useDeletePersona } from '@/hooks/use-personas'
+import { useCreateAsset } from '@/hooks/use-asset'
+import { usePersonaStore } from '@/hooks/use-persona-store'
 import { useUpdateShowcase } from '@/hooks/use-showcases'
-import { Persona, AssetRequest, ShowcaseRequest, PersonaRequest, ShowcaseResponse } from "bc-wallet-openapi";
-import { toast } from 'sonner';
-import { useQueryClient } from "@tanstack/react-query";
-import { showcaseToShowcaseRequest } from "@/lib/parsers";
-import apiClient from "@/lib/apiService";
+import { Persona, AssetRequest, ShowcaseRequest, PersonaRequest, ShowcaseResponse } from 'bc-wallet-openapi'
+import { toast } from 'sonner'
+import { useQueryClient } from '@tanstack/react-query'
+import { showcaseToShowcaseRequest } from '@/lib/parsers'
+import apiClient from '@/lib/apiService'
 import { useUpdateScenario as useUpdateIssuanceScenario } from '@/hooks/use-onboarding'
 import { useUpdateScenario as useUpdatePresentationScenario } from '@/hooks/use-presentation'
 
@@ -18,14 +18,22 @@ type PersonaRequestWithImageType = PersonaRequest & {
 }
 
 export const usePersonaAdapter = () => {
-  const [headshotImage, setHeadshotImage] = useState<string | null>(null);
-  const [isHeadshotImageEdited, setIsHeadshotImageEdited] = useState<boolean>(false);
-  const [bodyImage, setBodyImage] = useState<string | null>(null);
-  const [isBodyImageEdited, setIsBodyImageEdited] = useState<boolean>(false);
-  const [selectedPersonaId, setSelectedPersonaId] = useState<string | null>(null);
+  const {
+    setEditMode,
+    personaState,
+    setStepState,
+    draftHeadshotImage,
+    draftBodyImage,
+    setDraftImages,
+  } = usePersonaStore()
 
-  const { setEditMode, personaState, setStepState } = usePersonaStore();
-  const { selectedPersonaIds, setSelectedPersonaIds, showcase, setShowcase, currentShowcaseSlug } = useShowcaseStore();
+  const [headshotImage, setHeadshotImage] = useState<string | null>(draftHeadshotImage)
+  const [isHeadshotImageEdited, setIsHeadshotImageEdited] = useState<boolean>(!!draftHeadshotImage)
+  const [bodyImage, setBodyImage] = useState<string | null>(draftBodyImage)
+  const [isBodyImageEdited, setIsBodyImageEdited] = useState<boolean>(!!draftBodyImage)
+  const [selectedPersonaId, setSelectedPersonaId] = useState<string | null>(null)
+
+  const { selectedPersonaIds, setSelectedPersonaIds, showcase, setShowcase, currentShowcaseSlug } = useShowcaseStore()
   const queryClient = useQueryClient()
 
   const { data: personasData, isLoading } = usePersonas();
@@ -37,13 +45,13 @@ export const usePersonaAdapter = () => {
   const { mutateAsync: updateIssuanceScenario } = useUpdateIssuanceScenario();
   const { mutateAsync: updatePresentationScenario } = useUpdatePresentationScenario();
 
-  const InvalidPersonaState = async() => {
+  const InvalidPersonaState = useCallback(async () => {
     queryClient.invalidateQueries({ queryKey: ['personas'] })
-  };
+  }, [queryClient])
 
   useEffect(() => {
     InvalidPersonaState()
-  },[])
+  },[InvalidPersonaState])
 
   const selectedPersona = personasData?.personas?.find((p: Persona) => p.id === selectedPersonaId) || null
 
@@ -72,7 +80,6 @@ export const usePersonaAdapter = () => {
   const updateShowcaseWithPersona = useCallback(
     async (personaIds: string[]) => {
       if (!currentShowcaseSlug || !showcase) return
-
       try {
         // Get the current state of the showcase from the server to compare against
         const showcaseResponse = (await apiClient.get(`/showcases/${currentShowcaseSlug}`)) as ShowcaseResponse
@@ -81,20 +88,14 @@ export const usePersonaAdapter = () => {
           throw new Error('Showcase data is undefined')
         }
 
-        const oldPersonaIds = new Set(serverShowcase.personas?.map((p) => p.id) || [])
+        const oldPersonaIds = new Set(showcase.personas?.map((p:any) => p.id) || [])
         const newPersonaIds = new Set(personaIds)
-
-        // Update the showcase's main persona list first
-        const parsed = showcaseToShowcaseRequest(serverShowcase)
-        const updatedShowcase: ShowcaseRequest = {
-          ...parsed,
-          personas: Array.from(newPersonaIds),
-        }
-        await updateShowcase(updatedShowcase as ShowcaseRequest)
 
         // Determine which personas were added and removed
         const addedPersonaIds = personaIds.filter((id) => !oldPersonaIds.has(id))
         const removedPersonaIds = [...oldPersonaIds].filter((id) => !newPersonaIds.has(id))
+
+        const scenariosToRemove: string[] = []
 
         // Iterate through scenarios and update them based on persona changes
         for (const scenario of serverShowcase.scenarios || []) {
@@ -114,9 +115,17 @@ export const usePersonaAdapter = () => {
 
             // Handle persona removals from the scenario
             if (removedPersonaIds.length > 0) {
-              const initialLength = scenarioPersonaIds.length
-              scenarioPersonaIds = scenarioPersonaIds.filter((id:any) => !removedPersonaIds.includes(id))
-              if (scenarioPersonaIds.length !== initialLength) {
+              const personasBeforeRemoval = [...scenarioPersonaIds] // Define personasBeforeRemoval here
+
+              const personasAfterFiltering = scenarioPersonaIds.filter((id:any) => !removedPersonaIds.includes(id))
+
+              const shouldRemoveScenario = personasAfterFiltering.length === 0
+
+              if (shouldRemoveScenario) {
+                scenariosToRemove.push(scenario.slug)
+                continue // Skip further processing for this scenario
+              } else if (personasAfterFiltering.length !== personasBeforeRemoval.length) {
+                scenarioPersonaIds = personasAfterFiltering // Update scenarioPersonaIds only if not removing the whole scenario
                 needsUpdate = true
               }
             }
@@ -156,6 +165,19 @@ export const usePersonaAdapter = () => {
           }
         }
 
+        let finalScenarios = serverShowcase.scenarios || []
+        if (scenariosToRemove.length > 0) {
+            finalScenarios = finalScenarios.filter(s => !scenariosToRemove.includes(s.slug))
+        }
+
+        const parsed = showcaseToShowcaseRequest(serverShowcase)
+        const updatedShowcaseRequest: ShowcaseRequest = {
+            ...parsed,
+            personas: Array.from(newPersonaIds),
+            scenarios: finalScenarios.map(s => s.id), // Include updated scenarios
+        }
+        await updateShowcase(updatedShowcaseRequest)
+
         // Refresh the local showcase state to reflect all changes
         const updatedShowcaseResponse = (await apiClient.get(
           `/showcases/${currentShowcaseSlug}`,
@@ -190,7 +212,11 @@ export const usePersonaAdapter = () => {
       }
 
       setSelectedPersonaId(null)
-      setStepState('no-selection')
+      if (updatedPersonaIds.length === 0) {
+        setStepState('creating-new')
+      } else {
+        setStepState('no-selection')
+      }
 
       toast.success('Persona has been deleted.')
     } catch (error) {
@@ -209,22 +235,24 @@ export const usePersonaAdapter = () => {
     updateShowcaseWithPersona,
   ])
 
+
   const handlePersonaSelect = useCallback(
     (persona: Persona) => {
       setSelectedPersonaId(persona.id)
       setStepState('editing-persona')
+      setDraftImages({ headshot: null, body: null }) // Clear drafts when selecting a persona
     },
-    [setSelectedPersonaId, setStepState],
+    [setSelectedPersonaId, setStepState, setDraftImages],
   )
 
   const handleCreateNew = useCallback(() => {
     setSelectedPersonaId(null)
-    setHeadshotImage(null)
-    setBodyImage(null)
-    setIsHeadshotImageEdited(false)
-    setIsBodyImageEdited(false)
+    setHeadshotImage(draftHeadshotImage)
+    setBodyImage(draftBodyImage)
+    setIsHeadshotImageEdited(!!draftHeadshotImage)
+    setIsBodyImageEdited(!!draftBodyImage)
     setStepState('creating-new')
-  }, [setSelectedPersonaId, setStepState])
+  }, [setSelectedPersonaId, setStepState, draftHeadshotImage, draftBodyImage])
 
   const handleCancel = useCallback(() => {
     setSelectedPersonaId(null)
@@ -299,6 +327,7 @@ export const usePersonaAdapter = () => {
 
           setSelectedPersonaId(newPersonaId)
           setStepState('editing-persona')
+          setDraftImages({ headshot: null, body: null }) // Clear drafts after successful save
           toast.success('Character has been created.')
         }
 
@@ -325,18 +354,30 @@ export const usePersonaAdapter = () => {
       showcase,
       updateShowcaseWithPersona,
       setStepState,
+      setDraftImages,
     ],
   )
+
+  // Custom setters to update both local and draft state
+  const setDraftHeadshotImage = (image: string | null) => {
+    setHeadshotImage(image)
+    setDraftImages({ headshot: image })
+  }
+
+  const setDraftBodyImage = (image: string | null) => {
+    setBodyImage(image)
+    setDraftImages({ body: image })
+  }
 
   return {
     selectedPersonaId,
     setSelectedPersonaId,
     headshotImage,
-    setHeadshotImage,
+    setHeadshotImage: setDraftHeadshotImage,
     isHeadshotImageEdited,
     setIsHeadshotImageEdited,
     bodyImage,
-    setBodyImage,
+    setBodyImage: setDraftBodyImage,
     isBodyImageEdited,
     setIsBodyImageEdited,
     selectedPersona,

--- a/apps/bc-wallet-showcase-creator/hooks/use-persona-store.ts
+++ b/apps/bc-wallet-showcase-creator/hooks/use-persona-store.ts
@@ -1,39 +1,52 @@
 'use client'
 
-import { create } from "zustand";
-import { immer } from "zustand/middleware/immer";
+import { create } from 'zustand'
+import { immer } from 'zustand/middleware/immer'
 
-type PersonaState = "editing-persona" | "no-selection" | "creating-new";
+type PersonaState = 'editing-persona' | 'no-selection' | 'creating-new'
 interface State {
-  editMode: boolean;
-  personaState: PersonaState;
+  editMode: boolean
+  personaState: PersonaState
+  draftHeadshotImage: string | null
+  draftBodyImage: string | null
 }
 
 interface Actions {
-  setEditMode: (mode: boolean) => void;
-  setStepState: (state: PersonaState) => void;
-  reset: () => void;
+  setEditMode: (mode: boolean) => void
+  setStepState: (state: PersonaState) => void
+  setDraftImages: (images: { headshot?: string | null; body?: string | null }) => void
+  reset: () => void
 }
 
 export const usePersonaStore = create<State & Actions>()(
   immer((set) => ({
     editMode: false,
-    personaState: "creating-new",
+    personaState: 'creating-new',
+    draftHeadshotImage: null,
+    draftBodyImage: null,
 
     setStepState: (newState) =>
       set((state) => {
-        state.personaState = newState;
+        state.personaState = newState
       }),
 
     setEditMode: (mode) =>
       set((state) => {
-        state.editMode = mode;
+        state.editMode = mode
+      }),
+
+    setDraftImages: ({ headshot, body }) =>
+      set((state) => {
+        if (headshot !== undefined) state.draftHeadshotImage = headshot
+        if (body !== undefined) state.draftBodyImage = body
       }),
 
     reset: () =>
       set((state) => {
-        state.personaState = "creating-new";
-        state.editMode = false;
+        state.personaState = 'creating-new'
+        state.editMode = false
+        state.draftHeadshotImage = null
+        state.draftBodyImage = null
       }),
-  }))
-);
+  })),
+)

--- a/apps/bc-wallet-showcase-creator/hooks/use-presentation-adapter.tsx
+++ b/apps/bc-wallet-showcase-creator/hooks/use-presentation-adapter.tsx
@@ -45,7 +45,7 @@ export const usePresentationAdapter = (showcaseSlug?: string) => {
     setStepState,
     stepState,
     selectedScenario,
-    // updateScenario,
+    updateScenario: updateLocalScenario,
     removeScenario,
     selectedStep,
     setSelectedStep,
@@ -156,6 +156,31 @@ export const usePresentationAdapter = (showcaseSlug?: string) => {
           if(result && result.presentationScenario) {
             scenarioIds.push(result.presentationScenario.id);
             toast.success(`Scenario created for ${scenario.personas[0] ? selectedPersonas.find(p => p.id === scenario.personas[0])?.name || 'persona' : 'persona'}`);
+            
+            // Update the scenario with the returned slug to prevent duplicate creation
+            if (result.presentationScenario.slug && scenario.personas && scenario.personas.length > 0) {
+              const personaId = scenario.personas[0];
+              const personaScenarioList = selectedPersonas
+                .find(p => p.id === personaId)
+                ? Array.from(personaScenarios.get(personaId) || [])
+                : [];
+              
+              const scenarioIndex = personaScenarioList.findIndex(s => 
+                s.name === scenario.name && 
+                s.description === scenario.description &&
+                //@ts-expect-error : slug is present in the scenario
+                !s.slug // Only update scenarios that don't have a slug yet
+              );
+              
+              if (scenarioIndex >= 0) {
+                updateLocalScenario(personaId, scenarioIndex, {
+                  ...scenario,
+                  //@ts-expect-error : slug is present in the scenario
+                  slug: result.presentationScenario.slug,
+                  id: result.presentationScenario.id
+                });
+              }
+            }
           } else {
             throw new Error('Invalid response format');
           }
@@ -238,7 +263,7 @@ export const usePresentationAdapter = (showcaseSlug?: string) => {
           result = await createScenarios([scenario])
           if (result && result.success) {
             toast.success('Scenarios created successfully')
-            router.push(`/${tenantId}/showcases/create/publish`)
+            // router.push(`/${tenantId}/showcases/create/publish`)
           } else {
             throw new Error('Invalid response format');
           }

--- a/apps/bc-wallet-showcase-creator/hooks/use-presentation-creation.ts
+++ b/apps/bc-wallet-showcase-creator/hooks/use-presentation-creation.ts
@@ -1,11 +1,392 @@
+import { create } from 'zustand'
+import { immer } from 'zustand/middleware/immer'
+import { enableMapSet } from 'immer'
 import { useEffect, useState } from 'react'
+import { sampleAction } from '@/lib/steps'
 import { useShowcaseStore } from '@/hooks/use-showcases-store'
 import { useHelpersStore } from '@/hooks/use-helpers-store'
 import { usePersonas } from './use-personas'
-import type { Persona, PresentationScenarioRequest, StepActionRequest, StepRequest } from 'bc-wallet-openapi'
+import type { Persona, PresentationScenarioRequest, Step, StepActionRequest, StepRequest } from 'bc-wallet-openapi'
+import { StepActionType, StepType } from 'bc-wallet-openapi'
 import { useShowcase } from './use-showcases'
 import { presentationScenarioToPresentationScenarioRequest } from '@/lib/parsers'
-import { usePresentationCreationStore } from './use-presentation-store'
+
+enableMapSet()
+
+type SelectedStep = {
+  stepIndex: number
+  scenarioIndex: number
+} | null
+interface PresentationCreationState {
+  personaScenariosMap: Record<string, PresentationScenarioRequest[]>
+  activePersonaId: string | null
+  activeScenarioIndex: number
+  stepState: 'editing-basic' | 'editing-issue' | 'no-selection' | 'creating-new' | 'editing-scenario'
+  selectedScenarioId: string | null
+  selectedStep: SelectedStep
+
+  // Actions
+  initializeWithScenarios: (scenariosMap: Record<string, PresentationScenarioRequest[]>) => void
+  setActivePersonaId: (id: string | null) => void
+  setActiveScenarioIndex: (index: number) => void
+  updatePersonaSteps: (personaId: string, scenarioIndex: number, steps: StepRequest[]) => void
+  addActionToStep: (personaId: string, stepIndex: number, action: StepActionRequest) => void
+  addPersonaScenario: (persona: Persona, relayerId: string) => void
+  duplicateScenario: (scenarioIndex: number) => void
+  deleteScenario: (scenarioIndex: number) => void
+  addStep: (personaId: string, scenarioIndex: number, stepData: StepRequest) => void
+  updateStep: (personaId: string, scenarioIndex: number, stepIndex: number, stepData: StepRequest) => void
+  deleteStep: (personaId: string, scenarioIndex: number, stepIndex: number) => void
+  moveStep: (personaId: string, scenarioIndex: number, oldIndex: number, newIndex: number) => void
+  duplicateStep: (personaId: string, scenarioIndex: number, stepIndex: number) => void
+  setStepState: (
+    state: 'editing-basic' | 'editing-issue' | 'no-selection' | 'creating-new' | 'editing-scenario',
+  ) => void
+  setSelectedScenarioId: (id: string | null) => void
+  updateScenario: (personaId: string, scenarioIndex: number, scenarioData: PresentationScenarioRequest) => void
+  removeScenario: (personaId: string, scenarioIndex: number) => void
+  setSelectedStep: (selectedStep: SelectedStep) => void
+  selectStep: (stepIndex: number, scenarioIndex: number) => void
+
+  reset: () => void
+}
+
+const usePresentationCreationStore = create<PresentationCreationState>()(
+  immer((set) => ({
+    personaScenariosMap: {},
+    activePersonaId: null as string | null,
+    activeScenarioIndex: 0,
+    stepState: 'no-selection' as PresentationCreationState['stepState'],
+    selectedScenarioId: null as string | null,
+    selectedStep: null as SelectedStep | null,
+
+    initializeWithScenarios: (scenariosMap) =>
+      set((state) => {
+        state.personaScenariosMap = scenariosMap
+        state.selectedStep = null
+      }),
+
+    setSelectedScenarioId: (id) =>
+      set((state) => {
+        state.selectedScenarioId = id
+      }),
+
+    setActivePersonaId: (id) =>
+      set((state) => {
+        state.activePersonaId = id
+        state.activeScenarioIndex = 0
+      }),
+
+    setActiveScenarioIndex: (index) =>
+      set((state) => {
+        state.activeScenarioIndex = index
+      }),
+
+    updatePersonaSteps: (personaId, scenarioIndex, steps) =>
+      set((state) => {
+        if (!state.personaScenariosMap[personaId]) return
+
+        const scenarios = state.personaScenariosMap[personaId]
+        if (scenarioIndex < 0 || scenarioIndex >= scenarios.length) return
+
+        scenarios[scenarioIndex].steps = steps
+      }),
+
+    addActionToStep: (personaId, stepIndex, action) =>
+      set((state) => {
+        if (!state.personaScenariosMap[personaId]) return
+
+        const scenarios = state.personaScenariosMap[personaId]
+        const scenarioIndex = state.activeScenarioIndex
+
+        if (scenarioIndex < 0 || scenarioIndex >= scenarios.length) return
+
+        const steps = scenarios[scenarioIndex].steps
+        if (stepIndex < 0 || stepIndex >= steps.length) return
+
+        const step = steps[stepIndex]
+        steps[stepIndex] = {
+          ...step,
+          actions: [...(step.actions || []), action],
+        }
+      }),
+
+    addPersonaScenario: (persona, relayerId) =>
+      set((state) => {
+        if (state.personaScenariosMap[persona.id]) return
+
+        const defaultScenario: PresentationScenarioRequest = {
+          name: "Add your student exam results",
+          description: `Presentation scenario for ${persona.name}`,
+          steps: [
+            {
+              title: `Scan the QR code to start sharing`,
+              description: `Open the BC Wallet app and scan the QR code on the College website to start sharing your teacher credential with College Test.`,
+              order: 0,
+              type: 'HUMAN_TASK',
+              actions: [{
+                title: "Scan QR Code",
+                actionType: StepActionType.SetupConnection,
+                text: "Scan this QR code with your wallet to connect",
+              }],
+            },
+            {
+              title: `Confirm the information to send`,
+              description: `BC Wallet will now ask you to confirm what to send. Notice how it will only share if the credential has not expired, not even the expiry date itself gets shared. You don't have to share anything else for it to be trustable.`,
+              order: 1,
+              type: 'SERVICE',
+              actions: [sampleAction],
+            },
+            {
+              title: `You are done!`,
+              description: `You proved that you're a student, and you can now pass this online exam. It only took a few seconds, you revealed minimal information, and Test College could easily and automatically trust what you sent.`,
+              order: 2,
+              type: 'HUMAN_TASK',
+              actions: [sampleAction],
+            },
+          ],
+          personas: [persona.id],
+          hidden: false,
+          relyingParty: relayerId,
+        }
+
+        state.personaScenariosMap[persona.id] = [defaultScenario]
+      }),
+
+    duplicateScenario: (scenarioIndex) =>
+      set((state) => {
+        const personaId = state.activePersonaId
+        if (!personaId || !state.personaScenariosMap[personaId]) return
+
+        const scenarios = state.personaScenariosMap[personaId]
+        if (scenarioIndex < 0 || scenarioIndex >= scenarios.length) return
+
+        const scenarioToDuplicate = scenarios[scenarioIndex]
+        const duplicatedScenario = JSON.parse(JSON.stringify(scenarioToDuplicate))
+
+        duplicatedScenario.name = `${duplicatedScenario.name} (Copy)`
+        duplicatedScenario.slug = null
+
+        const newScenarioIndex = scenarios.length
+
+        duplicatedScenario.steps = duplicatedScenario.steps.map((step: StepRequest, idx: number) => ({
+          ...step,
+          id: `step-${newScenarioIndex}-${idx}-${Date.now()}`,
+          scenarioIndex: newScenarioIndex,
+        }))
+
+        return {
+          personaScenariosMap: {
+            ...state.personaScenariosMap,
+            [personaId]: [...scenarios, duplicatedScenario],
+          },
+        }
+        // scenarios.push(duplicatedScenario)
+      }),
+
+    addStep: (personaId, scenarioIndex, stepData) =>
+      set((state) => {
+        const existingScenarios = state.personaScenariosMap[personaId]
+        if (!existingScenarios) return
+
+        const scenarios = state.personaScenariosMap[personaId]
+        if (scenarioIndex < 0 || scenarioIndex >= scenarios.length) return
+
+        const currentSteps = scenarios[scenarioIndex].steps
+
+        const newStep = {
+          ...stepData,
+          id: `step-${scenarioIndex}-${currentSteps.length}-${Date.now()}`,
+          order: currentSteps.length,
+          type: stepData.type || 'HUMAN_TASK',
+          actions: stepData.actions || [],
+        }
+
+        scenarios[scenarioIndex].steps.push(newStep)
+      }),
+
+    updateStep: (personaId, scenarioIndex, stepIndex, stepData) =>
+      set((state) => {
+        if (!state.personaScenariosMap[personaId]) return
+
+        const scenarios = state.personaScenariosMap[personaId]
+        if (scenarioIndex < 0 || scenarioIndex >= scenarios.length) return
+
+        const steps = scenarios[scenarioIndex].steps
+        if (stepIndex < 0 || stepIndex >= steps.length) return
+
+        steps[stepIndex] = {
+          ...steps[stepIndex],
+          ...stepData,
+          order: stepIndex,
+        }
+      }),
+
+    deleteStep: (personaId, scenarioIndex, stepIndex) =>
+      set((state) => {
+        if (!state.personaScenariosMap[personaId]) return
+
+        const scenarios = state.personaScenariosMap[personaId]
+        if (scenarioIndex < 0 || scenarioIndex >= scenarios.length) return
+
+        const steps = scenarios[scenarioIndex].steps
+        if (stepIndex < 0 || stepIndex >= steps.length) return
+
+        // Remove the step
+        steps.splice(stepIndex, 1)
+
+        // Update orders for all steps
+        steps.forEach((step, idx) => {
+          step.order = idx
+        })
+      }),
+
+    moveStep: (personaId, scenarioIndex, oldIndex, newIndex) =>
+      set((state) => {
+        if (!state.personaScenariosMap[personaId]) return
+
+        const scenarios = state.personaScenariosMap[personaId]
+        if (scenarioIndex < 0 || scenarioIndex >= scenarios.length) return
+
+        const steps = scenarios[scenarioIndex].steps
+        if (oldIndex < 0 || oldIndex >= steps.length || newIndex < 0 || newIndex >= steps.length) return
+
+        const newSteps = [...steps]
+
+        const [movedStep] = newSteps.splice(oldIndex, 1)
+
+        newSteps.splice(newIndex, 0, movedStep)
+
+        newSteps.forEach((step, idx) => {
+          step.order = idx
+        })
+
+        scenarios[scenarioIndex].steps = newSteps
+      }),
+
+    duplicateStep: (personaId, scenarioIndex, stepIndex) =>
+      set((state) => {
+        if (!state.personaScenariosMap[personaId]) {
+          console.log('No persona found with ID:', personaId)
+          return
+        }
+
+        const scenarios = state.personaScenariosMap[personaId]
+        if (scenarioIndex < 0 || scenarioIndex >= scenarios.length) {
+          console.log('Invalid scenario index:', scenarioIndex)
+          return
+        }
+
+        const scenario = scenarios[scenarioIndex]
+        const steps = scenario.steps
+
+        if (stepIndex < 0 || stepIndex >= steps.length) {
+          console.log('Invalid step index:', stepIndex)
+          return
+        }
+
+        const stepToDuplicate = steps[stepIndex]
+
+        const duplicatedStep = {
+          ...JSON.parse(JSON.stringify(stepToDuplicate)),
+          title: `${stepToDuplicate.title} (Copy)`,
+          id: `step-${scenarioIndex}-${stepIndex}-${Date.now()}`,
+          order: stepIndex + 1,
+        }
+
+        steps.splice(stepIndex + 1, 0, duplicatedStep)
+
+        steps.forEach((step, idx) => {
+          step.order = idx
+        })
+      }),
+
+    deleteScenario: (scenarioIndex) =>
+      set((state) => {
+        const personaId = state.activePersonaId
+        if (!personaId || !state.personaScenariosMap[personaId]) return
+
+        const scenarios = state.personaScenariosMap[personaId]
+        if (scenarioIndex < 0 || scenarioIndex >= scenarios.length) return
+
+        scenarios.splice(scenarioIndex, 1)
+      }),
+
+    setStepState: (stepState) =>
+      set((state) => {
+        state.stepState = stepState
+      }),
+
+    updateScenario: (personaId, scenarioIndex, scenarioData) =>
+      set((state) => {
+        if (!state.personaScenariosMap[personaId]) return
+
+        const scenarios = state.personaScenariosMap[personaId]
+        if (scenarioIndex < 0 || scenarioIndex >= scenarios.length) return
+
+        scenarios[scenarioIndex] = {
+          ...scenarios[scenarioIndex],
+          ...scenarioData,
+        }
+      }),
+
+    removeScenario: (personaId, scenarioIndex) =>
+      set((state) => {
+        if (!state.personaScenariosMap[personaId]) return
+
+        const scenarios = state.personaScenariosMap[personaId]
+        if (scenarioIndex < 0 || scenarioIndex >= scenarios.length) return
+
+        scenarios.splice(scenarioIndex, 1)
+
+        if (state.activeScenarioIndex === scenarioIndex) {
+          state.activeScenarioIndex = Math.max(0, scenarios.length - 1)
+        } else if (state.activeScenarioIndex > scenarioIndex) {
+          state.activeScenarioIndex--
+        }
+      }),
+
+    setSelectedStep: (selectedStep) =>
+      set((state) => {
+        state.selectedStep = selectedStep
+      }),
+
+    selectStep: (stepIndex, scenarioIndex) =>
+      set((state) => {
+        state.selectedStep = { stepIndex, scenarioIndex }
+
+        if (state.activeScenarioIndex !== scenarioIndex) {
+          state.activeScenarioIndex = scenarioIndex
+        }
+
+        if (state.activePersonaId && state.personaScenariosMap[state.activePersonaId]) {
+          const scenarios = state.personaScenariosMap[state.activePersonaId]
+
+          if (scenarioIndex >= 0 && scenarioIndex < scenarios.length) {
+            const steps = scenarios[scenarioIndex].steps
+
+            if (stepIndex >= 0 && stepIndex < steps.length) {
+              const currentStep = steps[stepIndex]
+
+              if (currentStep.type === StepType.Service) {
+                state.stepState = 'editing-basic'
+              } else {
+                state.stepState = 'editing-basic'
+              }
+            }
+          }
+        }
+      }),
+
+    reset: () => {
+      set((state) => {
+        state.personaScenariosMap = {}
+        state.activePersonaId = null
+        state.activeScenarioIndex = 0
+      })
+    },
+  })),
+)
 
 export const usePresentationCreation = (showcaseSlug?: string) => {
   const { selectedPersonaIds } = useShowcaseStore()
@@ -13,15 +394,6 @@ export const usePresentationCreation = (showcaseSlug?: string) => {
   const { data: personasData } = usePersonas()
   const { data: showcaseData, isLoading: isShowcaseLoading } = useShowcase(showcaseSlug || '')
   const [isInitialized, setIsInitialized] = useState(false)
-  const [lastShowcaseSlug, setLastShowcaseSlug] = useState<string | undefined>(undefined)
-  
-  // Reset initialization when showcase slug changes
-  useEffect(() => {
-    if (lastShowcaseSlug !== showcaseSlug) {
-      setIsInitialized(false)
-      setLastShowcaseSlug(showcaseSlug)
-    }
-  }, [showcaseSlug, lastShowcaseSlug])
 
   const {
     personaScenariosMap,
@@ -52,36 +424,21 @@ export const usePresentationCreation = (showcaseSlug?: string) => {
     reset,
   } = usePresentationCreationStore()
 
-
-  // Cleanup stale personas from store when selectedPersonaIds changes
   useEffect(() => {
-    const currentStorePersonas = Object.keys(personaScenariosMap)
-    const stalePersonas = currentStorePersonas.filter(id => !selectedPersonaIds.includes(id))
-    
-    
-    if (stalePersonas.length > 0) {
-      // Instead of trying to clean up selectively, just reset and let reinitialization handle it
-      reset()
-      setIsInitialized(false)
-    }
-  }, [selectedPersonaIds, personaScenariosMap, reset])
-
-  useEffect(() => {    
-    if (showcaseSlug && showcaseData && !isInitialized && personasData) {
+    if (showcaseSlug && showcaseData && !isShowcaseLoading && !isInitialized) {
       const showcase = showcaseData?.showcase
 
       if (showcase) {
-        const presentationScenarios = showcase.scenarios?.filter((scenario) => scenario.type === 'PRESENTATION') || []
+        const issuanceScenarios = showcase.scenarios?.filter((scenario) => scenario.type === 'PRESENTATION') || []
 
-        if (presentationScenarios.length === 0) {
+        const personaScenariosData: Record<string, PresentationScenarioRequest[]> = {}
+        
+        if (issuanceScenarios.length === 0) {
           initializeWithScenarios(personaScenariosMap)
           setIsInitialized(true)
           return
         } else {
-          const personaScenariosData: Record<string, PresentationScenarioRequest[]> = {}
-          
-          presentationScenarios.forEach((scenario, index) => {
-            
+          issuanceScenarios.forEach((scenario) => {
             if (scenario.personas && scenario.personas.length > 0) {
               scenario.personas.forEach((persona) => {
                 if (!personaScenariosData[persona.id]) {
@@ -91,8 +448,6 @@ export const usePresentationCreation = (showcaseSlug?: string) => {
                 const scenarioRequest = presentationScenarioToPresentationScenarioRequest(scenario)
                 personaScenariosData[persona.id].push(scenarioRequest)
               })
-            } else {
-              console.log('Scenario has no personas, skipping')
             }
           })
 
@@ -136,27 +491,6 @@ export const usePresentationCreation = (showcaseSlug?: string) => {
           setIsInitialized(true)
         }
       }
-    } else if (!showcaseSlug && !isInitialized && Object.keys(personaScenariosMap).length === 0) {
-      // Only create default scenarios if:
-      // 1. No showcase slug (not in showcase context)
-      // 2. Not already initialized 
-      // 3. No existing scenarios in the map (to avoid overriding showcase-loaded scenarios)
-      const personas = (personasData?.personas || []).filter((persona: Persona) =>
-        selectedPersonaIds.includes(persona.id),
-      )
-      
-      if (personas.length > 0) {
-        personas.forEach((persona: Persona) => {
-          if (!personaScenariosMap[persona.id]) {
-            addPersonaScenario(persona, relayerId)
-          }
-        })
-
-        if (!activePersonaId) {
-          setActivePersonaId(personas[0].id)
-        }
-      }
-      setIsInitialized(true)
     }
   }, [
     showcaseSlug,
@@ -166,17 +500,39 @@ export const usePresentationCreation = (showcaseSlug?: string) => {
     initializeWithScenarios,
     activePersonaId,
     setActivePersonaId,
-    relayerId,
+  ])
+
+   useEffect(() => {
+    if (showcaseSlug && isInitialized) return
+
+    const personas = (personasData?.personas || []).filter((persona: Persona) =>
+      selectedPersonaIds.includes(persona.id),
+    )
+
+    personas.forEach((persona: Persona) => {
+      if (!personaScenariosMap[persona.id]) {
+        addPersonaScenario(persona, relayerId)
+      }
+    })
+
+    if (!activePersonaId && personas.length > 0) {
+      setActivePersonaId(personas[0].id)
+    }
+  }, [
+    showcaseSlug,
+    isInitialized,
     personasData,
-    addPersonaScenario,
     selectedPersonaIds,
     personaScenariosMap,
+    activePersonaId,
+    relayerId,
+    addPersonaScenario,
+    setActivePersonaId,
   ])
 
   const selectedPersonas = (personasData?.personas || []).filter((persona: Persona) =>
     selectedPersonaIds.includes(persona.id),
   )
-  
 
   const personaScenarios = new Map(Object.entries(personaScenariosMap))
 
@@ -212,8 +568,7 @@ export const usePresentationCreation = (showcaseSlug?: string) => {
     setStepState,
     stepState,
     selectedScenario,
-    updateScenario: (scenarioData: PresentationScenarioRequest) =>
-      activePersonaId && updateScenario(activePersonaId, activeScenarioIndex, scenarioData),
+    updateScenario,
     removeScenario: () => activePersonaId && removeScenario(activePersonaId, activeScenarioIndex),
     selectedStep,
     setSelectedStep,

--- a/apps/bc-wallet-showcase-creator/locales/en/common.json
+++ b/apps/bc-wallet-showcase-creator/locales/en/common.json
@@ -284,7 +284,12 @@
     "subtitle": "Today's date will be appended to the filename for versioning.\nex. MyShowcase_v3_(mm-dd-yyyy)",
     "modal_description": "Once submitted, you won't be able to make further edits until the review is complete.",
     "modal_button": "CONFIRM & SUBMIT FOR REVIEW",
-    "modal_description2": "Do you want to proceed?"
+    "modal_description2": "Do you want to proceed?",
+    "validation_error_title": "Validation Errors"
+  },
+  "error": {
+    "title": "Error",
+    "description": "Please correct the following issues to proceed:"
   },
   "navigation": {
     "general_label": "General",

--- a/apps/bc-wallet-showcase-creator/locales/fr/common.json
+++ b/apps/bc-wallet-showcase-creator/locales/fr/common.json
@@ -275,7 +275,12 @@
     "modal_button": "CONFIMER ET ENVOYER POUR LA REVISION",
     "modal_description2": "Voulez-vous continuer?",
     "publish_info_credentials": "Recevera les attestations suivantes:",
-    "publish_info_subtitle": "Saisissez et vérifiez les détails de la vitrine."
+    "publish_info_subtitle": "Saisissez et vérifiez les détails de la vitrine.",
+    "validation_error_title": "Validation Errors"
+  },
+  "error": {
+    "title": "Error",
+    "description": "Please correct the following issues to proceed:"
   },
   "navigation": {
     "general_label": "Général",


### PR DESCRIPTION
- Implemented validation to ensure at least one attribute or predicate is added for each credential in the EditProofRequest component.
- Added checks for predicate values to ensure they are exactly 8 digits (YYYYMMDD) and not '0'.
- Enhanced the ProofAttribute component to display a date format hint and restrict input length for condition values.
- Updated CreateScenariosScreen to conditionally render the delete scenario button based on the number of scenarios.
- Added error handling and success messages in the onboarding adapter for better user feedback.
- Refactored persona and presentation scenario management in the respective hooks to improve state handling and clarity.
- Updated localization files to include new validation error messages for better user experience.